### PR TITLE
Create the authz GetAuthorization function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,9 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
-* nothing
+### Improvements
+
+* (x/authz) Create the GetAuthorization to replace the previously removed GetCleanAuthorization. [#222](https://github.com/provenance-io/cosmos-sdk/pull/222)
 
 ---
 

--- a/x/authz/keeper/keeper.go
+++ b/x/authz/keeper/keeper.go
@@ -256,18 +256,18 @@ func (k Keeper) GetAuthorizations(ctx sdk.Context, grantee sdk.AccAddress, grant
 //	- No grant is found.
 //	- A grant is found, but it is expired.
 //	- There was an error getting the authorization from the grant.
-func (k Keeper) FindAuthorization(ctx sdk.Context, grantee sdk.AccAddress, granter sdk.AccAddress, msgType string) (cap authz.Authorization, expiration time.Time) {
+func (k Keeper) FindAuthorization(ctx sdk.Context, grantee sdk.AccAddress, granter sdk.AccAddress, msgType string) (cap authz.Authorization, expiration *time.Time) {
 	grant, found := k.getGrant(ctx, grantStoreKey(grantee, granter, msgType))
 	if !found || grant.Expiration.Before(ctx.BlockHeader().Time) {
-		return nil, time.Time{}
+		return nil, &time.Time{}
 	}
 
 	auth, err := grant.GetAuthorization()
 	if err != nil {
-		return nil, time.Time{}
+		return nil, &time.Time{}
 	}
 
-	return auth, *grant.Expiration
+	return auth, grant.Expiration
 }
 
 // IterateGrants iterates over all authorization grants

--- a/x/authz/keeper/keeper.go
+++ b/x/authz/keeper/keeper.go
@@ -258,7 +258,7 @@ func (k Keeper) GetAuthorizations(ctx sdk.Context, grantee sdk.AccAddress, grant
 //	- There was an error getting the authorization from the grant.
 func (k Keeper) FindAuthorization(ctx sdk.Context, grantee sdk.AccAddress, granter sdk.AccAddress, msgType string) (cap authz.Authorization, expiration *time.Time) {
 	grant, found := k.getGrant(ctx, grantStoreKey(grantee, granter, msgType))
-	if !found || grant.Expiration.Before(ctx.BlockHeader().Time) {
+	if !found || (grant.Expiration != nil && grant.Expiration.Before(ctx.BlockHeader().Time)) {
 		return nil, &time.Time{}
 	}
 

--- a/x/authz/keeper/keeper.go
+++ b/x/authz/keeper/keeper.go
@@ -251,6 +251,25 @@ func (k Keeper) GetAuthorizations(ctx sdk.Context, grantee sdk.AccAddress, grant
 	return authorizations, nil
 }
 
+// FindAuthorization returns an `Authorization` and it's expiration time.
+// A nil Authorization is returned under the following circumstances:
+//	- No grant is found.
+//	- A grant is found, but it is expired.
+//	- There was an error getting the authorization from the grant.
+func (k Keeper) FindAuthorization(ctx sdk.Context, grantee sdk.AccAddress, granter sdk.AccAddress, msgType string) (cap authz.Authorization, expiration time.Time) {
+	grant, found := k.getGrant(ctx, grantStoreKey(grantee, granter, msgType))
+	if !found || grant.Expiration.Before(ctx.BlockHeader().Time) {
+		return nil, time.Time{}
+	}
+
+	auth, err := grant.GetAuthorization()
+	if err != nil {
+		return nil, time.Time{}
+	}
+
+	return auth, *grant.Expiration
+}
+
 // IterateGrants iterates over all authorization grants
 // This function should be used with caution because it can involve significant IO operations.
 // It should not be used in query or msg services without charging additional gas.

--- a/x/authz/keeper/keeper.go
+++ b/x/authz/keeper/keeper.go
@@ -251,20 +251,20 @@ func (k Keeper) GetAuthorizations(ctx sdk.Context, grantee sdk.AccAddress, grant
 	return authorizations, nil
 }
 
-// FindAuthorization returns an `Authorization` and it's expiration time.
+// GetAuthorization returns an `Authorization` and it's expiration time.
 // A nil Authorization is returned under the following circumstances:
 //	- No grant is found.
 //	- A grant is found, but it is expired.
 //	- There was an error getting the authorization from the grant.
-func (k Keeper) FindAuthorization(ctx sdk.Context, grantee sdk.AccAddress, granter sdk.AccAddress, msgType string) (cap authz.Authorization, expiration *time.Time) {
+func (k Keeper) GetAuthorization(ctx sdk.Context, grantee sdk.AccAddress, granter sdk.AccAddress, msgType string) (authz.Authorization, *time.Time) {
 	grant, found := k.getGrant(ctx, grantStoreKey(grantee, granter, msgType))
 	if !found || (grant.Expiration != nil && grant.Expiration.Before(ctx.BlockHeader().Time)) {
-		return nil, &time.Time{}
+		return nil, nil
 	}
 
 	auth, err := grant.GetAuthorization()
 	if err != nil {
-		return nil, &time.Time{}
+		return nil, nil
 	}
 
 	return auth, grant.Expiration


### PR DESCRIPTION
## Description

With v0.46, Cosmos removed the `GetCleanAuthorization` function. That was done because expired authorization deletion is now done in the `BeginBlocker`. However, by doing so, there is no longer a way to look up an authorization and it's expiration.

This PR Creates a `GetAuthorization` function that is basically a replacement for `GetCleanAuthorization`, but without the attempt to delete expired authorizations.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
