### PR TITLE
Fix auth genesis account number handling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Bug Fixes
 
 * (x/auth) Add the missing account number case to the sim state decoder. TODO: link PR.
+* (x/auth) Handle missing account numbers during InitGenesis. TODO: link PR.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,9 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
-* nothing
+### Bug Fixes
+
+* (x/auth) Add the missing account number case to the sim state decoder. TODO: link PR.
 
 ---
 

--- a/x/auth/keeper/genesis.go
+++ b/x/auth/keeper/genesis.go
@@ -18,8 +18,11 @@ func (ak AccountKeeper) InitGenesis(ctx sdk.Context, data types.GenesisState) {
 	}
 	accounts = types.SanitizeGenesisAccounts(accounts)
 
-	for _, a := range accounts {
-		acc := ak.NewAccount(ctx, a)
+	lastAccountNumber := uint64(0)
+	for _, acc := range accounts {
+		for lastAccountNumber < acc.GetAccountNumber() {
+			lastAccountNumber = ak.GetNextAccountNumber(ctx)
+		}
 		ak.SetAccount(ctx, acc)
 	}
 

--- a/x/auth/keeper/genesis.go
+++ b/x/auth/keeper/genesis.go
@@ -18,6 +18,7 @@ func (ak AccountKeeper) InitGenesis(ctx sdk.Context, data types.GenesisState) {
 	}
 	accounts = types.SanitizeGenesisAccounts(accounts)
 
+	// Set the accounts and make sure the global account number matches the largest account number (even if zero).
 	var lastAccNum *uint64
 	for _, acc := range accounts {
 		accNum := acc.GetAccountNumber()

--- a/x/auth/keeper/genesis.go
+++ b/x/auth/keeper/genesis.go
@@ -18,10 +18,12 @@ func (ak AccountKeeper) InitGenesis(ctx sdk.Context, data types.GenesisState) {
 	}
 	accounts = types.SanitizeGenesisAccounts(accounts)
 
-	lastAccountNumber := uint64(0)
+	var lastAccNum *uint64
 	for _, acc := range accounts {
-		for lastAccountNumber < acc.GetAccountNumber() {
-			lastAccountNumber = ak.GetNextAccountNumber(ctx)
+		accNum := acc.GetAccountNumber()
+		for lastAccNum == nil || *lastAccNum < accNum {
+			n := ak.GetNextAccountNumber(ctx)
+			lastAccNum = &n
 		}
 		ak.SetAccount(ctx, acc)
 	}

--- a/x/auth/keeper/keeper_test.go
+++ b/x/auth/keeper/keeper_test.go
@@ -3,14 +3,26 @@ package keeper_test
 import (
 	"testing"
 
+	massert "github.com/magiconair/properties/assert"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/tendermint/tendermint/libs/log"
+	tmproto "github.com/tendermint/tendermint/proto/tendermint/types"
+
 	"github.com/cosmos/cosmos-sdk/baseapp"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/ed25519"
 	"github.com/cosmos/cosmos-sdk/simapp"
+	"github.com/cosmos/cosmos-sdk/store"
+	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/x/auth/keeper"
 	"github.com/cosmos/cosmos-sdk/x/auth/types"
+	paramskeeper "github.com/cosmos/cosmos-sdk/x/params/keeper"
+	paramstypes "github.com/cosmos/cosmos-sdk/x/params/types"
+	dbm "github.com/tendermint/tm-db"
 )
 
 const (
@@ -145,4 +157,145 @@ func TestSupply_ValidatePermissions(t *testing.T) {
 	otherAcc := types.NewEmptyModuleAccount("other", "other")
 	err = app.AccountKeeper.ValidatePermissions(otherAcc)
 	require.Error(t, err)
+}
+
+func TestInitGenesis(tt *testing.T) {
+	authKey := sdk.NewKVStoreKey(types.StoreKey)
+	paramsKey := sdk.NewKVStoreKey(paramstypes.StoreKey)
+	paramsTKey := sdk.NewTransientStoreKey(paramstypes.TStoreKey)
+	newCtx := func(t *testing.T) sdk.Context {
+		db := dbm.NewMemDB()
+		cms := store.NewCommitMultiStore(db)
+		cms.MountStoreWithDB(authKey, storetypes.StoreTypeIAVL, db)
+		cms.MountStoreWithDB(paramsKey, storetypes.StoreTypeIAVL, db)
+		cms.MountStoreWithDB(paramsTKey, storetypes.StoreTypeTransient, db)
+		err := cms.LoadLatestVersion()
+		if err != nil {
+			panic(err)
+		}
+		return sdk.NewContext(cms, tmproto.Header{}, false, log.NewNopLogger())
+	}
+	newAccountKeeper := func(t *testing.T) keeper.AccountKeeper {
+		encConf := simapp.MakeTestEncodingConfig()
+		paramsKeeper := paramskeeper.NewKeeper(encConf.Codec, encConf.Amino, paramsKey, paramsTKey)
+		return keeper.NewAccountKeeper(
+			encConf.Codec, authKey, paramsKeeper.Subspace(types.ModuleName),
+			types.ProtoBaseAccount, map[string][]string{}, sdk.Bech32MainPrefix,
+		)
+	}
+
+	tt.Run("params are set", func(t *testing.T) {
+		genState := types.GenesisState{
+			Params: types.Params{
+				MaxMemoCharacters:      types.DefaultMaxMemoCharacters + 1,
+				TxSigLimit:             types.DefaultTxSigLimit + 1,
+				TxSizeCostPerByte:      types.DefaultTxSizeCostPerByte + 1,
+				SigVerifyCostED25519:   types.DefaultSigVerifyCostED25519 + 1,
+				SigVerifyCostSecp256k1: types.DefaultSigVerifyCostSecp256k1 + 1,
+			},
+			Accounts: []*codectypes.Any{},
+		}
+
+		accKeeper := newAccountKeeper(t)
+		ctx := newCtx(t)
+
+		accKeeper.InitGenesis(ctx, genState)
+
+		params := accKeeper.GetParams(ctx)
+		massert.Equal(t, genState.Params.MaxMemoCharacters, params.MaxMemoCharacters, "MaxMemoCharacters")
+		massert.Equal(t, genState.Params.TxSigLimit, params.TxSigLimit, "TxSigLimit")
+		massert.Equal(t, genState.Params.TxSizeCostPerByte, params.TxSizeCostPerByte, "TxSizeCostPerByte")
+		massert.Equal(t, genState.Params.SigVerifyCostED25519, params.SigVerifyCostED25519, "SigVerifyCostED25519")
+		massert.Equal(t, genState.Params.SigVerifyCostSecp256k1, params.SigVerifyCostSecp256k1, "SigVerifyCostSecp256k1")
+	})
+
+	tt.Run("duplicate account numbers are fixed", func(t *testing.T) {
+		pubKey1 := ed25519.GenPrivKey().PubKey()
+		pubKey2 := ed25519.GenPrivKey().PubKey()
+		accts := []types.AccountI{
+			&types.BaseAccount{
+				Address:       sdk.AccAddress(pubKey1.Address()).String(),
+				PubKey:        codectypes.UnsafePackAny(pubKey1),
+				AccountNumber: 0,
+				Sequence:      5,
+			},
+			&types.ModuleAccount{
+				BaseAccount: &types.BaseAccount{
+					Address:       types.NewModuleAddress("testing").String(),
+					PubKey:        nil,
+					AccountNumber: 0,
+					Sequence:      6,
+				},
+				Name:        "testing",
+				Permissions: nil,
+			},
+			&types.BaseAccount{
+				Address:       sdk.AccAddress(pubKey2.Address()).String(),
+				PubKey:        codectypes.UnsafePackAny(pubKey2),
+				AccountNumber: 5,
+				Sequence:      7,
+			},
+		}
+		genState := types.GenesisState{
+			Params:   types.DefaultParams(),
+			Accounts: nil,
+		}
+		for _, acct := range accts {
+			genState.Accounts = append(genState.Accounts, codectypes.UnsafePackAny(acct))
+		}
+
+		accKeeper := newAccountKeeper(t)
+		ctx := newCtx(t)
+
+		accKeeper.InitGenesis(ctx, genState)
+
+		keeperAccts := accKeeper.GetAllAccounts(ctx)
+		assert.GreaterOrEqual(t, len(keeperAccts), len(accts), "number of accounts in the keeper vs in genesis state")
+		for i, genAcct := range accts {
+			genAcctAddr := genAcct.GetAddress()
+			var keeperAcct types.AccountI
+			for _, kacct := range keeperAccts {
+				if genAcctAddr.Equals(kacct.GetAddress()) {
+					keeperAcct = kacct
+					break
+				}
+			}
+			if assert.NotNilf(t, keeperAcct, "genesis account %s not in keeper accounts", genAcctAddr) {
+				assert.Equal(t, genAcct.GetPubKey(), keeperAcct.GetPubKey())
+				assert.Equal(t, genAcct.GetSequence(), keeperAcct.GetSequence())
+				if i == 1 {
+					assert.Equal(t, 1, int(keeperAcct.GetAccountNumber()))
+				} else {
+					assert.Equal(t, genAcct.GetSequence(), keeperAcct.GetSequence())
+				}
+			}
+		}
+
+		// The 3rd account has account number 5, so the next should be 6.
+		nextNum := accKeeper.GetNextAccountNumber(ctx)
+		assert.Equal(t, 6, int(nextNum))
+	})
+
+	tt.Run("one zero account still sets global account number", func(t *testing.T) {
+		pubKey1 := ed25519.GenPrivKey().PubKey()
+		genState := types.GenesisState{
+			Params: types.DefaultParams(),
+			Accounts: []*codectypes.Any{
+				codectypes.UnsafePackAny(&types.BaseAccount{
+					Address:       sdk.AccAddress(pubKey1.Address()).String(),
+					PubKey:        codectypes.UnsafePackAny(pubKey1),
+					AccountNumber: 0,
+					Sequence:      5,
+				}),
+			},
+		}
+
+		accKeeper := newAccountKeeper(t)
+		ctx := newCtx(t)
+
+		accKeeper.InitGenesis(ctx, genState)
+
+		nextNum := accKeeper.GetNextAccountNumber(ctx)
+		assert.Equal(t, 1, int(nextNum))
+	})
 }

--- a/x/auth/simulation/decoder.go
+++ b/x/auth/simulation/decoder.go
@@ -7,6 +7,7 @@ import (
 	gogotypes "github.com/gogo/protobuf/types"
 
 	"github.com/cosmos/cosmos-sdk/codec"
+	sdktypes "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/kv"
 	"github.com/cosmos/cosmos-sdk/x/auth/types"
 )
@@ -40,6 +41,20 @@ func NewDecodeStore(ak AuthUnmarshaler) func(kvA, kvB kv.Pair) string {
 			ak.GetCodec().MustUnmarshal(kvB.Value, &globalAccNumberB)
 
 			return fmt.Sprintf("GlobalAccNumberA: %d\nGlobalAccNumberB: %d", globalAccNumberA, globalAccNumberB)
+
+		case bytes.Equal(kvA.Key[:len(types.AccountNumberStoreKeyPrefix)], types.AccountNumberStoreKeyPrefix):
+			var accNumA, accNumB sdktypes.AccAddress
+			err := accNumA.Unmarshal(kvA.Value)
+			if err != nil {
+				panic(err)
+			}
+
+			err = accNumB.Unmarshal(kvB.Value)
+			if err != nil {
+				panic(err)
+			}
+
+			return fmt.Sprintf("AccNumA: %s\nAccNumB: %s", accNumA, accNumB)
 
 		default:
 			panic(fmt.Sprintf("unexpected %s key %X (%s)", types.ModuleName, kvA.Key, kvA.Key))

--- a/x/auth/simulation/decoder_test.go
+++ b/x/auth/simulation/decoder_test.go
@@ -42,6 +42,10 @@ func TestDecodeStore(t *testing.T) {
 				Value: cdc.MustMarshal(&globalAccNumber),
 			},
 			{
+				Key:   types.AccountNumberStoreKey(5),
+				Value: acc.GetAddress().Bytes(),
+			},
+			{
 				Key:   []byte{0x99},
 				Value: []byte{0x99},
 			},
@@ -53,6 +57,7 @@ func TestDecodeStore(t *testing.T) {
 	}{
 		{"Account", fmt.Sprintf("%v\n%v", acc, acc)},
 		{"GlobalAccNumber", fmt.Sprintf("GlobalAccNumberA: %d\nGlobalAccNumberB: %d", globalAccNumber, globalAccNumber)},
+		{"AccNum", fmt.Sprintf("AccNumA: %s\nAccNumB: %s", acc.GetAddress(), acc.GetAddress())},
 		{"other", ""},
 	}
 


### PR DESCRIPTION
## Description

This fixes the account keeper's `InitGenesis` to
a) Allow for missing account numbers.
b) Only change account numbers that are duplicated.
c) Accounts with duplicated account numbers get updated account numbers in a deterministic way (based on the order they were originally provided).

This also adds a simulation decoder for the newly added `AccountNumberStoreKeyPrefix`.

Prior to this PR, all account numbers in the provided accounts were rewritten to be sequential starting with 0. The list was sorted by account number before doing that, but if there was a missing account number, all account numbers larger than the missing one were reduced by 1. Also, since `sort.Slice` isn't guaranteed to be stable, if there were accounts with duplicate account numbers, the final "sorted" list was nondeterministic.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
