### PR TITLE
Bring in v0.46.4 changes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Improvements
 
 * Bring in Cosmos-SDK [v0.46.4](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.46.4) changes [#362](https://github.com/provenance-io/cosmos-sdk/pull/362).
+* (server) [#362](https://github.com/provenance-io/cosmos-sdk/pull/362) Change the default for the re-added start command --iavl-disable-fastnode flag back to true to match the config default.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,9 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
-* nothing
+### Improvements
+
+* Bring in Cosmos-SDK [v0.46.4](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.46.4) changes [#362](https://github.com/provenance-io/cosmos-sdk/pull/362).
 
 ---
 
@@ -166,6 +168,25 @@ It also contains the Provenance Blockchain customizations that were part of [v0.
 
 # Cosmos-SDK releases
 
+## [v0.46.4](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.46.4) - 2022-11-01
+
+### Features
+
+* (x/auth) [#13612](https://github.com/cosmos/cosmos-sdk/pull/13612) Add `Query/ModuleAccountByName` endpoint for accessing the module account info by module name.
+
+### Improvements
+
+* (deps) Bump IAVL version to [v0.19.4](https://github.com/cosmos/iavl/releases/tag/v0.19.4).
+
+## Bug Fixes
+
+* (x/auth/tx) [#12474](https://github.com/cosmos/cosmos-sdk/pull/12474) Remove condition in GetTxsEvent that disallowed multiple equal signs, which would break event queries with base64 strings (i.e. query by signature).
+* (store) [#13530](https://github.com/cosmos/cosmos-sdk/pull/13530) Fix app-hash mismatch if upgrade migration commit is interrupted.
+
+## API Breaking Changes
+
+* (context) [#13063](https://github.com/cosmos/cosmos-sdk/pull/13063) Update `Context#CacheContext` to automatically emit all events on the parent context's `EventManager`.
+
 ## [v0.46.3](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.46.3) - 2022-10-20
 
 ATTENTION:
@@ -184,6 +205,7 @@ replace github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8
 
 * [#13435](https://github.com/cosmos/cosmos-sdk/pull/13435) Extend error context when a simulation fails.
 * (grpc) [#13485](https://github.com/cosmos/cosmos-sdk/pull/13485) Implement a new gRPC query, `/cosmos/base/node/v1beta1/config`, which provides operator configuration.
+* [#13577](https://github.com/cosmos/cosmos-sdk/pull/13577) Added `ApplicationQueryService` interface (the related method is added directly to the `Application` interface and `ApplicationQueryService` is removed in the future version). Applications implementing `ApplicationQueryService` enabling registration of module external gRPC services. When implemented the SDK will automatically register chain information query service introduced in [#13485](https://github.com/cosmos/cosmos-sdk/pull/13485).
 * (cli) [#13147](https://github.com/cosmos/cosmos-sdk/pull/13147) Add the `--append` flag to the `sign-batch` CLI cmd to combine the messages and sign those txs which are created with `--generate-only`.
 * (cli) [#13454](https://github.com/cosmos/cosmos-sdk/pull/13454) `sign-batch` CLI can now read multiple transaction files.
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -119,11 +119,47 @@ It also contains the Provenance Blockchain customizations that were part of [v0.
 
 ---
 
+## [v0.46.4](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.46.4) - 2022-11-01
+
+This release introduces a number of bug fixes, features and improvements.
+Notably, a new query for accessing module accounts info by module name (thanks @gsk967).
+
+Please see the [CHANGELOG](https://github.com/cosmos/cosmos-sdk/blob/release/v0.46.x/CHANGELOG.md) for an exhaustive list of changes.
+
+Full Commit History: https://github.com/cosmos/cosmos-sdk/compare/v0.46.3...v0.46.4
+
+**NOTE**: The changes mentioned in `v0.46.3` are **still** required:
+
+> Chains must add the following to their go.mod for the application:
+>
+> ```go
+> replace github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
+> ```
+
+### Features
+
+* (x/auth) [#13612](https://github.com/cosmos/cosmos-sdk/pull/13612) Add `Query/ModuleAccountByName` endpoint for accessing the module account info by module name.
+
+### Improvements
+
+* (deps) Bump IAVL version to [v0.19.4](https://github.com/cosmos/iavl/releases/tag/v0.19.4).
+
+## Bug Fixes
+
+* (x/auth/tx) [#12474](https://github.com/cosmos/cosmos-sdk/pull/12474) Remove condition in GetTxsEvent that disallowed multiple equal signs, which would break event queries with base64 strings (i.e. query by signature).
+* (store) [#13530](https://github.com/cosmos/cosmos-sdk/pull/13530) Fix app-hash mismatch if upgrade migration commit is interrupted.
+
+## API Breaking Changes
+
+* (context) [#13063](https://github.com/cosmos/cosmos-sdk/pull/13063) Update `Context#CacheContext` to automatically emit all events on the parent context's `EventManager`.
+
+---
+
 ## [v0.46.3](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.46.3) - 2022-10-20
 
 ATTENTION:
 
-This is a security release for the [Dragonberry security advisory](https://forum.cosmos.network/t/ibc-security-advisory-dragonberry/7702). 
+This is a security release for the [Dragonberry security advisory](https://forum.cosmos.network/t/ibc-security-advisory-dragonberry/7702).
 
 All users should upgrade immediately.
 

--- a/client/docs/swagger-ui/swagger.yaml
+++ b/client/docs/swagger-ui/swagger.yaml
@@ -2092,6 +2092,386 @@ paths:
                         }
       tags:
         - Query
+  /cosmos/auth/v1beta1/module_accounts/{name}:
+    get:
+      summary: ModuleAccountByName returns the module account info by module name
+      operationId: ModuleAccountByName
+      responses:
+        '200':
+          description: A successful response.
+          schema:
+            type: object
+            properties:
+              account:
+                type: object
+                properties:
+                  type_url:
+                    type: string
+                    description: >-
+                      A URL/resource name that uniquely identifies the type of
+                      the serialized
+
+                      protocol buffer message. This string must contain at least
+
+                      one "/" character. The last segment of the URL's path must
+                      represent
+
+                      the fully qualified name of the type (as in
+
+                      `path/google.protobuf.Duration`). The name should be in a
+                      canonical form
+
+                      (e.g., leading "." is not accepted).
+
+
+                      In practice, teams usually precompile into the binary all
+                      types that they
+
+                      expect it to use in the context of Any. However, for URLs
+                      which use the
+
+                      scheme `http`, `https`, or no scheme, one can optionally
+                      set up a type
+
+                      server that maps type URLs to message definitions as
+                      follows:
+
+
+                      * If no scheme is provided, `https` is assumed.
+
+                      * An HTTP GET on the URL must yield a
+                      [google.protobuf.Type][]
+                        value in binary format, or produce an error.
+                      * Applications are allowed to cache lookup results based
+                      on the
+                        URL, or have them precompiled into a binary to avoid any
+                        lookup. Therefore, binary compatibility needs to be preserved
+                        on changes to types. (Use versioned type names to manage
+                        breaking changes.)
+
+                      Note: this functionality is not currently available in the
+                      official
+
+                      protobuf release, and it is not used for type URLs
+                      beginning with
+
+                      type.googleapis.com.
+
+
+                      Schemes other than `http`, `https` (or the empty scheme)
+                      might be
+
+                      used with implementation specific semantics.
+                  value:
+                    type: string
+                    format: byte
+                    description: >-
+                      Must be a valid serialized protocol buffer of the above
+                      specified type.
+                description: >-
+                  `Any` contains an arbitrary serialized protocol buffer message
+                  along with a
+
+                  URL that describes the type of the serialized message.
+
+
+                  Protobuf library provides support to pack/unpack Any values in
+                  the form
+
+                  of utility functions or additional generated methods of the
+                  Any type.
+
+
+                  Example 1: Pack and unpack a message in C++.
+
+                      Foo foo = ...;
+                      Any any;
+                      any.PackFrom(foo);
+                      ...
+                      if (any.UnpackTo(&foo)) {
+                        ...
+                      }
+
+                  Example 2: Pack and unpack a message in Java.
+
+                      Foo foo = ...;
+                      Any any = Any.pack(foo);
+                      ...
+                      if (any.is(Foo.class)) {
+                        foo = any.unpack(Foo.class);
+                      }
+
+                   Example 3: Pack and unpack a message in Python.
+
+                      foo = Foo(...)
+                      any = Any()
+                      any.Pack(foo)
+                      ...
+                      if any.Is(Foo.DESCRIPTOR):
+                        any.Unpack(foo)
+                        ...
+
+                   Example 4: Pack and unpack a message in Go
+
+                       foo := &pb.Foo{...}
+                       any, err := ptypes.MarshalAny(foo)
+                       ...
+                       foo := &pb.Foo{}
+                       if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                         ...
+                       }
+
+                  The pack methods provided by protobuf library will by default
+                  use
+
+                  'type.googleapis.com/full.type.name' as the type URL and the
+                  unpack
+
+                  methods only use the fully qualified type name after the last
+                  '/'
+
+                  in the type URL, for example "foo.bar.com/x/y.z" will yield
+                  type
+
+                  name "y.z".
+
+
+
+                  JSON
+
+                  ====
+
+                  The JSON representation of an `Any` value uses the regular
+
+                  representation of the deserialized, embedded message, with an
+
+                  additional field `@type` which contains the type URL. Example:
+
+                      package google.profile;
+                      message Person {
+                        string first_name = 1;
+                        string last_name = 2;
+                      }
+
+                      {
+                        "@type": "type.googleapis.com/google.profile.Person",
+                        "firstName": <string>,
+                        "lastName": <string>
+                      }
+
+                  If the embedded message type is well-known and has a custom
+                  JSON
+
+                  representation, that representation will be embedded adding a
+                  field
+
+                  `value` which holds the custom JSON in addition to the `@type`
+
+                  field. Example (for message [google.protobuf.Duration][]):
+
+                      {
+                        "@type": "type.googleapis.com/google.protobuf.Duration",
+                        "value": "1.212s"
+                      }
+            description: >-
+              QueryModuleAccountByNameResponse is the response type for the
+              Query/ModuleAccountByName RPC method.
+        default:
+          description: An unexpected error response.
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+              code:
+                type: integer
+                format: int32
+              message:
+                type: string
+              details:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    type_url:
+                      type: string
+                      description: >-
+                        A URL/resource name that uniquely identifies the type of
+                        the serialized
+
+                        protocol buffer message. This string must contain at
+                        least
+
+                        one "/" character. The last segment of the URL's path
+                        must represent
+
+                        the fully qualified name of the type (as in
+
+                        `path/google.protobuf.Duration`). The name should be in
+                        a canonical form
+
+                        (e.g., leading "." is not accepted).
+
+
+                        In practice, teams usually precompile into the binary
+                        all types that they
+
+                        expect it to use in the context of Any. However, for
+                        URLs which use the
+
+                        scheme `http`, `https`, or no scheme, one can optionally
+                        set up a type
+
+                        server that maps type URLs to message definitions as
+                        follows:
+
+
+                        * If no scheme is provided, `https` is assumed.
+
+                        * An HTTP GET on the URL must yield a
+                        [google.protobuf.Type][]
+                          value in binary format, or produce an error.
+                        * Applications are allowed to cache lookup results based
+                        on the
+                          URL, or have them precompiled into a binary to avoid any
+                          lookup. Therefore, binary compatibility needs to be preserved
+                          on changes to types. (Use versioned type names to manage
+                          breaking changes.)
+
+                        Note: this functionality is not currently available in
+                        the official
+
+                        protobuf release, and it is not used for type URLs
+                        beginning with
+
+                        type.googleapis.com.
+
+
+                        Schemes other than `http`, `https` (or the empty scheme)
+                        might be
+
+                        used with implementation specific semantics.
+                    value:
+                      type: string
+                      format: byte
+                      description: >-
+                        Must be a valid serialized protocol buffer of the above
+                        specified type.
+                  description: >-
+                    `Any` contains an arbitrary serialized protocol buffer
+                    message along with a
+
+                    URL that describes the type of the serialized message.
+
+
+                    Protobuf library provides support to pack/unpack Any values
+                    in the form
+
+                    of utility functions or additional generated methods of the
+                    Any type.
+
+
+                    Example 1: Pack and unpack a message in C++.
+
+                        Foo foo = ...;
+                        Any any;
+                        any.PackFrom(foo);
+                        ...
+                        if (any.UnpackTo(&foo)) {
+                          ...
+                        }
+
+                    Example 2: Pack and unpack a message in Java.
+
+                        Foo foo = ...;
+                        Any any = Any.pack(foo);
+                        ...
+                        if (any.is(Foo.class)) {
+                          foo = any.unpack(Foo.class);
+                        }
+
+                     Example 3: Pack and unpack a message in Python.
+
+                        foo = Foo(...)
+                        any = Any()
+                        any.Pack(foo)
+                        ...
+                        if any.Is(Foo.DESCRIPTOR):
+                          any.Unpack(foo)
+                          ...
+
+                     Example 4: Pack and unpack a message in Go
+
+                         foo := &pb.Foo{...}
+                         any, err := ptypes.MarshalAny(foo)
+                         ...
+                         foo := &pb.Foo{}
+                         if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                           ...
+                         }
+
+                    The pack methods provided by protobuf library will by
+                    default use
+
+                    'type.googleapis.com/full.type.name' as the type URL and the
+                    unpack
+
+                    methods only use the fully qualified type name after the
+                    last '/'
+
+                    in the type URL, for example "foo.bar.com/x/y.z" will yield
+                    type
+
+                    name "y.z".
+
+
+
+                    JSON
+
+                    ====
+
+                    The JSON representation of an `Any` value uses the regular
+
+                    representation of the deserialized, embedded message, with
+                    an
+
+                    additional field `@type` which contains the type URL.
+                    Example:
+
+                        package google.profile;
+                        message Person {
+                          string first_name = 1;
+                          string last_name = 2;
+                        }
+
+                        {
+                          "@type": "type.googleapis.com/google.profile.Person",
+                          "firstName": <string>,
+                          "lastName": <string>
+                        }
+
+                    If the embedded message type is well-known and has a custom
+                    JSON
+
+                    representation, that representation will be embedded adding
+                    a field
+
+                    `value` which holds the custom JSON in addition to the
+                    `@type`
+
+                    field. Example (for message [google.protobuf.Duration][]):
+
+                        {
+                          "@type": "type.googleapis.com/google.protobuf.Duration",
+                          "value": "1.212s"
+                        }
+      parameters:
+        - name: name
+          in: path
+          required: true
+          type: string
+      tags:
+        - Query
   /cosmos/auth/v1beta1/params:
     get:
       summary: Params queries all parameters.
@@ -24430,6 +24810,171 @@ definitions:
 
 
       Since: cosmos-sdk 0.43
+  cosmos.auth.v1beta1.QueryModuleAccountByNameResponse:
+    type: object
+    properties:
+      account:
+        type: object
+        properties:
+          type_url:
+            type: string
+            description: >-
+              A URL/resource name that uniquely identifies the type of the
+              serialized
+
+              protocol buffer message. This string must contain at least
+
+              one "/" character. The last segment of the URL's path must
+              represent
+
+              the fully qualified name of the type (as in
+
+              `path/google.protobuf.Duration`). The name should be in a
+              canonical form
+
+              (e.g., leading "." is not accepted).
+
+
+              In practice, teams usually precompile into the binary all types
+              that they
+
+              expect it to use in the context of Any. However, for URLs which
+              use the
+
+              scheme `http`, `https`, or no scheme, one can optionally set up a
+              type
+
+              server that maps type URLs to message definitions as follows:
+
+
+              * If no scheme is provided, `https` is assumed.
+
+              * An HTTP GET on the URL must yield a [google.protobuf.Type][]
+                value in binary format, or produce an error.
+              * Applications are allowed to cache lookup results based on the
+                URL, or have them precompiled into a binary to avoid any
+                lookup. Therefore, binary compatibility needs to be preserved
+                on changes to types. (Use versioned type names to manage
+                breaking changes.)
+
+              Note: this functionality is not currently available in the
+              official
+
+              protobuf release, and it is not used for type URLs beginning with
+
+              type.googleapis.com.
+
+
+              Schemes other than `http`, `https` (or the empty scheme) might be
+
+              used with implementation specific semantics.
+          value:
+            type: string
+            format: byte
+            description: >-
+              Must be a valid serialized protocol buffer of the above specified
+              type.
+        description: >-
+          `Any` contains an arbitrary serialized protocol buffer message along
+          with a
+
+          URL that describes the type of the serialized message.
+
+
+          Protobuf library provides support to pack/unpack Any values in the
+          form
+
+          of utility functions or additional generated methods of the Any type.
+
+
+          Example 1: Pack and unpack a message in C++.
+
+              Foo foo = ...;
+              Any any;
+              any.PackFrom(foo);
+              ...
+              if (any.UnpackTo(&foo)) {
+                ...
+              }
+
+          Example 2: Pack and unpack a message in Java.
+
+              Foo foo = ...;
+              Any any = Any.pack(foo);
+              ...
+              if (any.is(Foo.class)) {
+                foo = any.unpack(Foo.class);
+              }
+
+           Example 3: Pack and unpack a message in Python.
+
+              foo = Foo(...)
+              any = Any()
+              any.Pack(foo)
+              ...
+              if any.Is(Foo.DESCRIPTOR):
+                any.Unpack(foo)
+                ...
+
+           Example 4: Pack and unpack a message in Go
+
+               foo := &pb.Foo{...}
+               any, err := ptypes.MarshalAny(foo)
+               ...
+               foo := &pb.Foo{}
+               if err := ptypes.UnmarshalAny(any, foo); err != nil {
+                 ...
+               }
+
+          The pack methods provided by protobuf library will by default use
+
+          'type.googleapis.com/full.type.name' as the type URL and the unpack
+
+          methods only use the fully qualified type name after the last '/'
+
+          in the type URL, for example "foo.bar.com/x/y.z" will yield type
+
+          name "y.z".
+
+
+
+          JSON
+
+          ====
+
+          The JSON representation of an `Any` value uses the regular
+
+          representation of the deserialized, embedded message, with an
+
+          additional field `@type` which contains the type URL. Example:
+
+              package google.profile;
+              message Person {
+                string first_name = 1;
+                string last_name = 2;
+              }
+
+              {
+                "@type": "type.googleapis.com/google.profile.Person",
+                "firstName": <string>,
+                "lastName": <string>
+              }
+
+          If the embedded message type is well-known and has a custom JSON
+
+          representation, that representation will be embedded adding a field
+
+          `value` which holds the custom JSON in addition to the `@type`
+
+          field. Example (for message [google.protobuf.Duration][]):
+
+              {
+                "@type": "type.googleapis.com/google.protobuf.Duration",
+                "value": "1.212s"
+              }
+    description: >-
+      QueryModuleAccountByNameResponse is the response type for the
+      Query/ModuleAccountByName RPC method.
   cosmos.auth.v1beta1.QueryModuleAccountsResponse:
     type: object
     properties:

--- a/proto/cosmos/auth/v1beta1/query.proto
+++ b/proto/cosmos/auth/v1beta1/query.proto
@@ -43,6 +43,11 @@ service Query {
     option (google.api.http).get = "/cosmos/auth/v1beta1/module_accounts";
   }
 
+  // ModuleAccountByName returns the module account info by module name
+  rpc ModuleAccountByName(QueryModuleAccountByNameRequest) returns (QueryModuleAccountByNameResponse) {
+    option (google.api.http).get = "/cosmos/auth/v1beta1/module_accounts/{name}";
+  }
+
   // Bech32Prefix queries bech32Prefix
   //
   // Since: cosmos-sdk 0.46
@@ -93,17 +98,6 @@ message QueryAccountRequest {
   string address = 1 [(cosmos_proto.scalar) = "cosmos.AddressString"];
 }
 
-// QueryModuleAccountsRequest is the request type for the Query/ModuleAccounts RPC method.
-//
-// Since: cosmos-sdk 0.46
-message QueryModuleAccountsRequest {}
-
-// QueryParamsResponse is the response type for the Query/Params RPC method.
-message QueryParamsResponse {
-  // params defines the parameters of the module.
-  Params params = 1 [(gogoproto.nullable) = false];
-}
-
 // QueryAccountResponse is the response type for the Query/Account RPC method.
 message QueryAccountResponse {
   // account defines the account of the corresponding address.
@@ -113,11 +107,32 @@ message QueryAccountResponse {
 // QueryParamsRequest is the request type for the Query/Params RPC method.
 message QueryParamsRequest {}
 
+// QueryParamsResponse is the response type for the Query/Params RPC method.
+message QueryParamsResponse {
+  // params defines the parameters of the module.
+  Params params = 1 [(gogoproto.nullable) = false];
+}
+
+// QueryModuleAccountsRequest is the request type for the Query/ModuleAccounts RPC method.
+//
+// Since: cosmos-sdk 0.46
+message QueryModuleAccountsRequest {}
+
 // QueryModuleAccountsResponse is the response type for the Query/ModuleAccounts RPC method.
 //
 // Since: cosmos-sdk 0.46
 message QueryModuleAccountsResponse {
   repeated google.protobuf.Any accounts = 1 [(cosmos_proto.accepts_interface) = "ModuleAccountI"];
+}
+
+// QueryModuleAccountByNameRequest is the request type for the Query/ModuleAccountByName RPC method.
+message QueryModuleAccountByNameRequest {
+  string name = 1;
+}
+
+// QueryModuleAccountByNameResponse is the response type for the Query/ModuleAccountByName RPC method.
+message QueryModuleAccountByNameResponse {
+  google.protobuf.Any account = 1 [(cosmos_proto.accepts_interface) = "ModuleAccountI"];
 }
 
 // Bech32PrefixRequest is the request type for Bech32Prefix rpc method.

--- a/server/start.go
+++ b/server/start.go
@@ -51,13 +51,13 @@ const (
 	FlagTrace              = "trace"
 	FlagInvCheckPeriod     = "inv-check-period"
 
-	FlagPruning           = "pruning"
-	FlagPruningKeepRecent = "pruning-keep-recent"
-	FlagPruningInterval   = "pruning-interval"
-	FlagIndexEvents       = "index-events"
-	FlagMinRetainBlocks   = "min-retain-blocks"
-	FlagIAVLCacheSize     = "iavl-cache-size"
-	FlagIAVLFastNode      = "iavl-disable-fastnode"
+	FlagPruning             = "pruning"
+	FlagPruningKeepRecent   = "pruning-keep-recent"
+	FlagPruningInterval     = "pruning-interval"
+	FlagIndexEvents         = "index-events"
+	FlagMinRetainBlocks     = "min-retain-blocks"
+	FlagIAVLCacheSize       = "iavl-cache-size"
+	FlagDisableIAVLFastNode = "iavl-disable-fastnode"
 
 	// state sync-related flags
 	FlagStateSyncSnapshotInterval   = "state-sync.snapshot-interval"
@@ -187,6 +187,8 @@ is performed. Note, when enabled, gRPC will also be automatically enabled.
 
 	cmd.Flags().Uint64(FlagStateSyncSnapshotInterval, 0, "State sync snapshot interval")
 	cmd.Flags().Uint32(FlagStateSyncSnapshotKeepRecent, 2, "State sync snapshot to keep")
+
+	cmd.Flags().Bool(FlagDisableIAVLFastNode, false, "Disable fast node for IAVL tree")
 
 	// add support for all Tendermint-specific command line options
 	tcmd.AddNodeFlags(cmd)

--- a/server/start.go
+++ b/server/start.go
@@ -188,7 +188,7 @@ is performed. Note, when enabled, gRPC will also be automatically enabled.
 	cmd.Flags().Uint64(FlagStateSyncSnapshotInterval, 0, "State sync snapshot interval")
 	cmd.Flags().Uint32(FlagStateSyncSnapshotKeepRecent, 2, "State sync snapshot to keep")
 
-	cmd.Flags().Bool(FlagDisableIAVLFastNode, false, "Disable fast node for IAVL tree")
+	cmd.Flags().Bool(FlagDisableIAVLFastNode, true, "Disable fast node for IAVL tree")
 
 	// add support for all Tendermint-specific command line options
 	tcmd.AddNodeFlags(cmd)

--- a/simapp/simd/cmd/root.go
+++ b/simapp/simd/cmd/root.go
@@ -295,7 +295,7 @@ func (a appCreator) newApp(logger log.Logger, db dbm.DB, traceStore io.Writer, a
 		baseapp.SetIndexEvents(cast.ToStringSlice(appOpts.Get(server.FlagIndexEvents))),
 		baseapp.SetSnapshot(snapshotStore, snapshotOptions),
 		baseapp.SetIAVLCacheSize(cast.ToInt(appOpts.Get(server.FlagIAVLCacheSize))),
-		baseapp.SetIAVLDisableFastNode(cast.ToBool(appOpts.Get(server.FlagIAVLFastNode))),
+		baseapp.SetIAVLDisableFastNode(cast.ToBool(appOpts.Get(server.FlagDisableIAVLFastNode))),
 	)
 }
 

--- a/types/context.go
+++ b/types/context.go
@@ -268,11 +268,18 @@ func (c Context) TransientStore(key storetypes.StoreKey) KVStore {
 
 // CacheContext returns a new Context with the multi-store cached and a new
 // EventManager. The cached context is written to the context when writeCache
-// is called.
+// is called. Note, events are automatically emitted on the parent context's
+// EventManager when the caller executes the write.
 func (c Context) CacheContext() (cc Context, writeCache func()) {
 	cms := c.MultiStore().CacheMultiStore()
 	cc = c.WithMultiStore(cms).WithEventManager(NewEventManager())
-	return cc, cms.Write
+
+	writeCache = func() {
+		c.EventManager().EmitEvents(cc.EventManager().Events())
+		cms.Write()
+	}
+
+	return cc, writeCache
 }
 
 var _ context.Context = Context{}

--- a/types/context_test.go
+++ b/types/context_test.go
@@ -42,6 +42,10 @@ func (s *contextTestSuite) TestCacheContext() {
 	s.Require().Equal(v1, cstore.Get(k1))
 	s.Require().Nil(cstore.Get(k2))
 
+	// emit some events
+	cctx.EventManager().EmitEvent(types.NewEvent("foo", types.NewAttribute("key", "value")))
+	cctx.EventManager().EmitEvent(types.NewEvent("bar", types.NewAttribute("key", "value")))
+
 	cstore.Set(k2, v2)
 	s.Require().Equal(v2, cstore.Get(k2))
 	s.Require().Nil(store.Get(k2))
@@ -49,6 +53,7 @@ func (s *contextTestSuite) TestCacheContext() {
 	write()
 
 	s.Require().Equal(v2, store.Get(k2))
+	s.Require().Len(ctx.EventManager().Events(), 2)
 }
 
 func (s *contextTestSuite) TestLogContext() {

--- a/x/auth/client/cli/query.go
+++ b/x/auth/client/cli/query.go
@@ -46,6 +46,7 @@ func GetQueryCmd() *cobra.Command {
 		GetAccountsCmd(),
 		QueryParamsCmd(),
 		QueryModuleAccountsCmd(),
+		QueryModuleAccountByNameCmd(),
 	)
 
 	return cmd
@@ -206,6 +207,40 @@ func QueryModuleAccountsCmd() *cobra.Command {
 			queryClient := types.NewQueryClient(clientCtx)
 
 			res, err := queryClient.ModuleAccounts(context.Background(), &types.QueryModuleAccountsRequest{})
+			if err != nil {
+				return err
+			}
+
+			return clientCtx.PrintProto(res)
+		},
+	}
+
+	flags.AddQueryFlagsToCmd(cmd)
+
+	return cmd
+}
+
+// QueryModuleAccountByNameCmd returns a command to
+func QueryModuleAccountByNameCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "module-account [module-name]",
+		Short:   "Query module account info by module name",
+		Args:    cobra.ExactArgs(1),
+		Example: fmt.Sprintf("%s q auth module-account auth", version.AppName),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx, err := client.GetClientQueryContext(cmd)
+			if err != nil {
+				return err
+			}
+
+			moduleName := args[0]
+			if len(moduleName) == 0 {
+				return fmt.Errorf("module name should not be empty")
+			}
+
+			queryClient := types.NewQueryClient(clientCtx)
+
+			res, err := queryClient.ModuleAccountByName(context.Background(), &types.QueryModuleAccountByNameRequest{Name: moduleName})
 			if err != nil {
 				return err
 			}

--- a/x/auth/client/testutil/suite.go
+++ b/x/auth/client/testutil/suite.go
@@ -1391,6 +1391,68 @@ func (s *IntegrationTestSuite) TestGetAccountsCmd() {
 	s.Require().NotEmpty(res.Accounts)
 }
 
+func (s *IntegrationTestSuite) TestQueryModuleAccountByNameCmd() {
+	val := s.network.Validators[0]
+
+	testCases := []struct {
+		name       string
+		moduleName string
+		expectErr  bool
+	}{
+		{
+			"invalid module name",
+			"gover",
+			true,
+		},
+		{
+			"valid module name",
+			"mint",
+			false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		s.Run(tc.name, func() {
+			clientCtx := val.ClientCtx
+
+			out, err := clitestutil.ExecTestCLICmd(clientCtx, authcli.QueryModuleAccountByNameCmd(), []string{
+				tc.moduleName,
+				fmt.Sprintf("--%s=json", tmcli.OutputFlag),
+			})
+			if tc.expectErr {
+				s.Require().Error(err)
+				s.Require().NotEqual("internal", err.Error())
+			} else {
+				var res authtypes.QueryModuleAccountByNameResponse
+				s.Require().NoError(val.ClientCtx.Codec.UnmarshalJSON(out.Bytes(), &res))
+
+				var account authtypes.AccountI
+				err := val.ClientCtx.InterfaceRegistry.UnpackAny(res.Account, &account)
+				s.Require().NoError(err)
+
+				moduleAccount, ok := account.(authtypes.ModuleAccountI)
+				s.Require().True(ok)
+				s.Require().Equal(tc.moduleName, moduleAccount.GetName())
+			}
+		})
+	}
+}
+
+func (s *IntegrationTestSuite) TestQueryModuleAccountsCmd() {
+	val := s.network.Validators[0]
+	clientCtx := val.ClientCtx
+
+	out, err := clitestutil.ExecTestCLICmd(clientCtx, authcli.QueryModuleAccountsCmd(), []string{
+		fmt.Sprintf("--%s=json", tmcli.OutputFlag),
+	})
+	s.Require().NoError(err)
+
+	var res authtypes.QueryModuleAccountsResponse
+	s.Require().NoError(val.ClientCtx.Codec.UnmarshalJSON(out.Bytes(), &res))
+	s.Require().NotEmpty(res.Accounts)
+}
+
 func TestGetBroadcastCommandOfflineFlag(t *testing.T) {
 	clientCtx := client.Context{}.WithOffline(true)
 	clientCtx = clientCtx.WithTxConfig(simapp.MakeTestEncodingConfig().TxConfig) //nolint:staticcheck

--- a/x/auth/keeper/grpc_query.go
+++ b/x/auth/keeper/grpc_query.go
@@ -135,6 +135,31 @@ func (ak AccountKeeper) ModuleAccounts(c context.Context, req *types.QueryModule
 	return &types.QueryModuleAccountsResponse{Accounts: modAccounts}, nil
 }
 
+// ModuleAccountByName returns module account by module name
+func (ak AccountKeeper) ModuleAccountByName(c context.Context, req *types.QueryModuleAccountByNameRequest) (*types.QueryModuleAccountByNameResponse, error) {
+	if req == nil {
+		return nil, status.Errorf(codes.InvalidArgument, "empty request")
+	}
+
+	if len(req.Name) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "module name is empty")
+	}
+
+	ctx := sdk.UnwrapSDKContext(c)
+	moduleName := req.Name
+
+	account := ak.GetModuleAccount(ctx, moduleName)
+	if account == nil {
+		return nil, status.Errorf(codes.NotFound, "account %s not found", moduleName)
+	}
+	any, err := codectypes.NewAnyWithValue(account)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, err.Error())
+	}
+
+	return &types.QueryModuleAccountByNameResponse{Account: any}, nil
+}
+
 // Bech32Prefix returns the keeper internally stored bech32 prefix.
 func (ak AccountKeeper) Bech32Prefix(ctx context.Context, req *types.Bech32PrefixRequest) (*types.Bech32PrefixResponse, error) {
 	bech32Prefix, err := ak.getBech32Prefix()

--- a/x/auth/keeper/grpc_query_test.go
+++ b/x/auth/keeper/grpc_query_test.go
@@ -348,6 +348,61 @@ func (suite *KeeperTestSuite) TestGRPCQueryModuleAccounts() {
 	}
 }
 
+func (suite *KeeperTestSuite) TestGRPCQueryModuleAccountByName() {
+	var req *types.QueryModuleAccountByNameRequest
+
+	testCases := []struct {
+		msg       string
+		malleate  func()
+		expPass   bool
+		posttests func(res *types.QueryModuleAccountByNameResponse)
+	}{
+		{
+			"success",
+			func() {
+				req = &types.QueryModuleAccountByNameRequest{Name: "mint"}
+			},
+			true,
+			func(res *types.QueryModuleAccountByNameResponse) {
+				var account types.AccountI
+				err := suite.app.InterfaceRegistry().UnpackAny(res.Account, &account)
+				suite.Require().NoError(err)
+
+				moduleAccount, ok := account.(types.ModuleAccountI)
+				suite.Require().True(ok)
+				suite.Require().Equal(moduleAccount.GetName(), "mint")
+			},
+		},
+		{
+			"invalid module name",
+			func() {
+				req = &types.QueryModuleAccountByNameRequest{Name: "gover"}
+			},
+			false,
+			func(res *types.QueryModuleAccountByNameResponse) {
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		suite.Run(fmt.Sprintf("Case %s", tc.msg), func() {
+			suite.SetupTest() // reset
+			tc.malleate()
+			ctx := sdk.WrapSDKContext(suite.ctx)
+			res, err := suite.queryClient.ModuleAccountByName(ctx, req)
+			if tc.expPass {
+				suite.Require().NoError(err)
+				suite.Require().NotNil(res)
+			} else {
+				suite.Require().Error(err)
+				suite.Require().Nil(res)
+			}
+
+			tc.posttests(res)
+		})
+	}
+}
+
 func (suite *KeeperTestSuite) TestBech32Prefix() {
 	suite.SetupTest() // reset
 	req := &types.Bech32PrefixRequest{}

--- a/x/auth/tx/service.go
+++ b/x/auth/tx/service.go
@@ -3,6 +3,7 @@ package tx
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/cosmos/cosmos-sdk/client/grpc/tmservice"
@@ -40,13 +41,18 @@ func NewTxServer(clientCtx client.Context, simulate baseAppSimulateFn, interface
 	}
 }
 
-var _ txtypes.ServiceServer = txServer{}
+var (
+	_ txtypes.ServiceServer = txServer{}
+
+	// EventRegex checks that an event string is formatted with {alphabetic}.{alphabetic}={value}
+	EventRegex = regexp.MustCompile(`^[a-zA-Z]+\.[a-zA-Z]+=\S+$`)
+)
 
 const (
 	eventFormat = "{eventType}.{eventAttribute}={value}"
 )
 
-// TxsByEvents implements the ServiceServer.TxsByEvents RPC method.
+// GetTxsEvent implements the ServiceServer.TxsByEvents RPC method.
 func (s txServer) GetTxsEvent(ctx context.Context, req *txtypes.GetTxsEventRequest) (*txtypes.GetTxsEventResponse, error) {
 	if req == nil {
 		return nil, status.Error(codes.InvalidArgument, "request cannot be nil")
@@ -70,7 +76,7 @@ func (s txServer) GetTxsEvent(ctx context.Context, req *txtypes.GetTxsEventReque
 	}
 
 	for _, event := range req.Events {
-		if !strings.Contains(event, "=") || strings.Count(event, "=") > 1 {
+		if !EventRegex.Match([]byte(event)) {
 			return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("invalid event; event %s should be of the format: %s", event, eventFormat))
 		}
 	}

--- a/x/auth/tx/service_test.go
+++ b/x/auth/tx/service_test.go
@@ -4,10 +4,12 @@ package tx_test
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
 	"github.com/cosmos/cosmos-sdk/client"
@@ -28,6 +30,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
 	authclient "github.com/cosmos/cosmos-sdk/x/auth/client"
 	authtest "github.com/cosmos/cosmos-sdk/x/auth/client/testutil"
+	authtx "github.com/cosmos/cosmos-sdk/x/auth/tx"
 	bankcli "github.com/cosmos/cosmos-sdk/x/bank/client/testutil"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 )
@@ -109,6 +112,81 @@ func (s *IntegrationTestSuite) SetupSuite() {
 func (s *IntegrationTestSuite) TearDownSuite() {
 	s.T().Log("tearing down integration test suite")
 	s.network.Cleanup()
+}
+
+func (s *IntegrationTestSuite) TestQueryBySig() {
+	// broadcast tx
+	txb := s.mkTxBuilder()
+	txbz, err := s.cfg.TxConfig.TxEncoder()(txb.GetTx())
+	s.Require().NoError(err)
+	resp, err := s.queryClient.BroadcastTx(context.Background(), &tx.BroadcastTxRequest{TxBytes: txbz, Mode: tx.BroadcastMode_BROADCAST_MODE_SYNC})
+	s.Require().NoError(err)
+	s.Require().NotEmpty(resp.TxResponse.TxHash)
+
+	s.Require().NoError(s.network.WaitForNextBlock())
+
+	// get the signature out of the builder
+	sigs, err := txb.GetTx().GetSignaturesV2()
+	s.Require().NoError(err)
+	s.Require().Len(sigs, 1)
+	sig, ok := sigs[0].Data.(*signing.SingleSignatureData)
+	s.Require().True(ok)
+
+	// encode, format, query
+	b64Sig := base64.StdEncoding.EncodeToString(sig.Signature)
+	sigFormatted := fmt.Sprintf("%s.%s='%s'", sdk.EventTypeTx, sdk.AttributeKeySignature, b64Sig)
+	res, err := s.queryClient.GetTxsEvent(context.Background(), &tx.GetTxsEventRequest{
+		Events:  []string{sigFormatted},
+		OrderBy: 0,
+		Page:    0,
+		Limit:   10,
+	})
+	s.Require().NoError(err)
+	s.Require().Len(res.Txs, 1)
+	s.Require().Len(res.Txs[0].Signatures, 1)
+	s.Require().Equal(res.Txs[0].Signatures[0], sig.Signature)
+
+	// bad format should error
+	_, err = s.queryClient.GetTxsEvent(context.Background(), &tx.GetTxsEventRequest{Events: []string{"tx.foo.bar='baz'"}})
+	s.Require().ErrorContains(err, "invalid event;")
+}
+
+func TestEventRegex(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name  string
+		event string
+		match bool
+	}{
+		{
+			name:  "valid: with quotes",
+			event: "tx.message='something'",
+			match: true,
+		},
+		{
+			name:  "valid: no quotes",
+			event: "tx.message=something",
+			match: true,
+		},
+		{
+			name:  "invalid: too many separators",
+			event: "tx.message.foo='bar'",
+			match: false,
+		},
+		{
+			name:  "valid: symbols ok",
+			event: "tx.signature='foobar/baz123=='",
+			match: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			match := authtx.EventRegex.Match([]byte(tc.event))
+			require.Equal(t, tc.match, match)
+		})
+	}
 }
 
 func (s IntegrationTestSuite) TestSimulateTx_GRPC() {

--- a/x/auth/types/query.pb.go
+++ b/x/auth/types/query.pb.go
@@ -176,91 +176,6 @@ func (m *QueryAccountRequest) XXX_DiscardUnknown() {
 
 var xxx_messageInfo_QueryAccountRequest proto.InternalMessageInfo
 
-// QueryModuleAccountsRequest is the request type for the Query/ModuleAccounts RPC method.
-//
-// Since: cosmos-sdk 0.46
-type QueryModuleAccountsRequest struct {
-}
-
-func (m *QueryModuleAccountsRequest) Reset()         { *m = QueryModuleAccountsRequest{} }
-func (m *QueryModuleAccountsRequest) String() string { return proto.CompactTextString(m) }
-func (*QueryModuleAccountsRequest) ProtoMessage()    {}
-func (*QueryModuleAccountsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_c451370b3929a27c, []int{3}
-}
-func (m *QueryModuleAccountsRequest) XXX_Unmarshal(b []byte) error {
-	return m.Unmarshal(b)
-}
-func (m *QueryModuleAccountsRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	if deterministic {
-		return xxx_messageInfo_QueryModuleAccountsRequest.Marshal(b, m, deterministic)
-	} else {
-		b = b[:cap(b)]
-		n, err := m.MarshalToSizedBuffer(b)
-		if err != nil {
-			return nil, err
-		}
-		return b[:n], nil
-	}
-}
-func (m *QueryModuleAccountsRequest) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_QueryModuleAccountsRequest.Merge(m, src)
-}
-func (m *QueryModuleAccountsRequest) XXX_Size() int {
-	return m.Size()
-}
-func (m *QueryModuleAccountsRequest) XXX_DiscardUnknown() {
-	xxx_messageInfo_QueryModuleAccountsRequest.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_QueryModuleAccountsRequest proto.InternalMessageInfo
-
-// QueryParamsResponse is the response type for the Query/Params RPC method.
-type QueryParamsResponse struct {
-	// params defines the parameters of the module.
-	Params Params `protobuf:"bytes,1,opt,name=params,proto3" json:"params"`
-}
-
-func (m *QueryParamsResponse) Reset()         { *m = QueryParamsResponse{} }
-func (m *QueryParamsResponse) String() string { return proto.CompactTextString(m) }
-func (*QueryParamsResponse) ProtoMessage()    {}
-func (*QueryParamsResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_c451370b3929a27c, []int{4}
-}
-func (m *QueryParamsResponse) XXX_Unmarshal(b []byte) error {
-	return m.Unmarshal(b)
-}
-func (m *QueryParamsResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	if deterministic {
-		return xxx_messageInfo_QueryParamsResponse.Marshal(b, m, deterministic)
-	} else {
-		b = b[:cap(b)]
-		n, err := m.MarshalToSizedBuffer(b)
-		if err != nil {
-			return nil, err
-		}
-		return b[:n], nil
-	}
-}
-func (m *QueryParamsResponse) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_QueryParamsResponse.Merge(m, src)
-}
-func (m *QueryParamsResponse) XXX_Size() int {
-	return m.Size()
-}
-func (m *QueryParamsResponse) XXX_DiscardUnknown() {
-	xxx_messageInfo_QueryParamsResponse.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_QueryParamsResponse proto.InternalMessageInfo
-
-func (m *QueryParamsResponse) GetParams() Params {
-	if m != nil {
-		return m.Params
-	}
-	return Params{}
-}
-
 // QueryAccountResponse is the response type for the Query/Account RPC method.
 type QueryAccountResponse struct {
 	// account defines the account of the corresponding address.
@@ -271,7 +186,7 @@ func (m *QueryAccountResponse) Reset()         { *m = QueryAccountResponse{} }
 func (m *QueryAccountResponse) String() string { return proto.CompactTextString(m) }
 func (*QueryAccountResponse) ProtoMessage()    {}
 func (*QueryAccountResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_c451370b3929a27c, []int{5}
+	return fileDescriptor_c451370b3929a27c, []int{3}
 }
 func (m *QueryAccountResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -315,7 +230,7 @@ func (m *QueryParamsRequest) Reset()         { *m = QueryParamsRequest{} }
 func (m *QueryParamsRequest) String() string { return proto.CompactTextString(m) }
 func (*QueryParamsRequest) ProtoMessage()    {}
 func (*QueryParamsRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_c451370b3929a27c, []int{6}
+	return fileDescriptor_c451370b3929a27c, []int{4}
 }
 func (m *QueryParamsRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -343,6 +258,91 @@ func (m *QueryParamsRequest) XXX_DiscardUnknown() {
 }
 
 var xxx_messageInfo_QueryParamsRequest proto.InternalMessageInfo
+
+// QueryParamsResponse is the response type for the Query/Params RPC method.
+type QueryParamsResponse struct {
+	// params defines the parameters of the module.
+	Params Params `protobuf:"bytes,1,opt,name=params,proto3" json:"params"`
+}
+
+func (m *QueryParamsResponse) Reset()         { *m = QueryParamsResponse{} }
+func (m *QueryParamsResponse) String() string { return proto.CompactTextString(m) }
+func (*QueryParamsResponse) ProtoMessage()    {}
+func (*QueryParamsResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_c451370b3929a27c, []int{5}
+}
+func (m *QueryParamsResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *QueryParamsResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_QueryParamsResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *QueryParamsResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryParamsResponse.Merge(m, src)
+}
+func (m *QueryParamsResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *QueryParamsResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryParamsResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_QueryParamsResponse proto.InternalMessageInfo
+
+func (m *QueryParamsResponse) GetParams() Params {
+	if m != nil {
+		return m.Params
+	}
+	return Params{}
+}
+
+// QueryModuleAccountsRequest is the request type for the Query/ModuleAccounts RPC method.
+//
+// Since: cosmos-sdk 0.46
+type QueryModuleAccountsRequest struct {
+}
+
+func (m *QueryModuleAccountsRequest) Reset()         { *m = QueryModuleAccountsRequest{} }
+func (m *QueryModuleAccountsRequest) String() string { return proto.CompactTextString(m) }
+func (*QueryModuleAccountsRequest) ProtoMessage()    {}
+func (*QueryModuleAccountsRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_c451370b3929a27c, []int{6}
+}
+func (m *QueryModuleAccountsRequest) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *QueryModuleAccountsRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_QueryModuleAccountsRequest.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *QueryModuleAccountsRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryModuleAccountsRequest.Merge(m, src)
+}
+func (m *QueryModuleAccountsRequest) XXX_Size() int {
+	return m.Size()
+}
+func (m *QueryModuleAccountsRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryModuleAccountsRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_QueryModuleAccountsRequest proto.InternalMessageInfo
 
 // QueryModuleAccountsResponse is the response type for the Query/ModuleAccounts RPC method.
 //
@@ -391,6 +391,96 @@ func (m *QueryModuleAccountsResponse) GetAccounts() []*types.Any {
 	return nil
 }
 
+// QueryModuleAccountByNameRequest is the request type for the Query/ModuleAccountByName RPC method.
+type QueryModuleAccountByNameRequest struct {
+	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+}
+
+func (m *QueryModuleAccountByNameRequest) Reset()         { *m = QueryModuleAccountByNameRequest{} }
+func (m *QueryModuleAccountByNameRequest) String() string { return proto.CompactTextString(m) }
+func (*QueryModuleAccountByNameRequest) ProtoMessage()    {}
+func (*QueryModuleAccountByNameRequest) Descriptor() ([]byte, []int) {
+	return fileDescriptor_c451370b3929a27c, []int{8}
+}
+func (m *QueryModuleAccountByNameRequest) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *QueryModuleAccountByNameRequest) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_QueryModuleAccountByNameRequest.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *QueryModuleAccountByNameRequest) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryModuleAccountByNameRequest.Merge(m, src)
+}
+func (m *QueryModuleAccountByNameRequest) XXX_Size() int {
+	return m.Size()
+}
+func (m *QueryModuleAccountByNameRequest) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryModuleAccountByNameRequest.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_QueryModuleAccountByNameRequest proto.InternalMessageInfo
+
+func (m *QueryModuleAccountByNameRequest) GetName() string {
+	if m != nil {
+		return m.Name
+	}
+	return ""
+}
+
+// QueryModuleAccountByNameResponse is the response type for the Query/ModuleAccountByName RPC method.
+type QueryModuleAccountByNameResponse struct {
+	Account *types.Any `protobuf:"bytes,1,opt,name=account,proto3" json:"account,omitempty"`
+}
+
+func (m *QueryModuleAccountByNameResponse) Reset()         { *m = QueryModuleAccountByNameResponse{} }
+func (m *QueryModuleAccountByNameResponse) String() string { return proto.CompactTextString(m) }
+func (*QueryModuleAccountByNameResponse) ProtoMessage()    {}
+func (*QueryModuleAccountByNameResponse) Descriptor() ([]byte, []int) {
+	return fileDescriptor_c451370b3929a27c, []int{9}
+}
+func (m *QueryModuleAccountByNameResponse) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *QueryModuleAccountByNameResponse) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_QueryModuleAccountByNameResponse.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *QueryModuleAccountByNameResponse) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_QueryModuleAccountByNameResponse.Merge(m, src)
+}
+func (m *QueryModuleAccountByNameResponse) XXX_Size() int {
+	return m.Size()
+}
+func (m *QueryModuleAccountByNameResponse) XXX_DiscardUnknown() {
+	xxx_messageInfo_QueryModuleAccountByNameResponse.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_QueryModuleAccountByNameResponse proto.InternalMessageInfo
+
+func (m *QueryModuleAccountByNameResponse) GetAccount() *types.Any {
+	if m != nil {
+		return m.Account
+	}
+	return nil
+}
+
 // Bech32PrefixRequest is the request type for Bech32Prefix rpc method.
 //
 // Since: cosmos-sdk 0.46
@@ -401,7 +491,7 @@ func (m *Bech32PrefixRequest) Reset()         { *m = Bech32PrefixRequest{} }
 func (m *Bech32PrefixRequest) String() string { return proto.CompactTextString(m) }
 func (*Bech32PrefixRequest) ProtoMessage()    {}
 func (*Bech32PrefixRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_c451370b3929a27c, []int{8}
+	return fileDescriptor_c451370b3929a27c, []int{10}
 }
 func (m *Bech32PrefixRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -441,7 +531,7 @@ func (m *Bech32PrefixResponse) Reset()         { *m = Bech32PrefixResponse{} }
 func (m *Bech32PrefixResponse) String() string { return proto.CompactTextString(m) }
 func (*Bech32PrefixResponse) ProtoMessage()    {}
 func (*Bech32PrefixResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_c451370b3929a27c, []int{9}
+	return fileDescriptor_c451370b3929a27c, []int{11}
 }
 func (m *Bech32PrefixResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -488,7 +578,7 @@ func (m *AddressBytesToStringRequest) Reset()         { *m = AddressBytesToStrin
 func (m *AddressBytesToStringRequest) String() string { return proto.CompactTextString(m) }
 func (*AddressBytesToStringRequest) ProtoMessage()    {}
 func (*AddressBytesToStringRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_c451370b3929a27c, []int{10}
+	return fileDescriptor_c451370b3929a27c, []int{12}
 }
 func (m *AddressBytesToStringRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -535,7 +625,7 @@ func (m *AddressBytesToStringResponse) Reset()         { *m = AddressBytesToStri
 func (m *AddressBytesToStringResponse) String() string { return proto.CompactTextString(m) }
 func (*AddressBytesToStringResponse) ProtoMessage()    {}
 func (*AddressBytesToStringResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_c451370b3929a27c, []int{11}
+	return fileDescriptor_c451370b3929a27c, []int{13}
 }
 func (m *AddressBytesToStringResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -582,7 +672,7 @@ func (m *AddressStringToBytesRequest) Reset()         { *m = AddressStringToByte
 func (m *AddressStringToBytesRequest) String() string { return proto.CompactTextString(m) }
 func (*AddressStringToBytesRequest) ProtoMessage()    {}
 func (*AddressStringToBytesRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_c451370b3929a27c, []int{12}
+	return fileDescriptor_c451370b3929a27c, []int{14}
 }
 func (m *AddressStringToBytesRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -629,7 +719,7 @@ func (m *AddressStringToBytesResponse) Reset()         { *m = AddressStringToByt
 func (m *AddressStringToBytesResponse) String() string { return proto.CompactTextString(m) }
 func (*AddressStringToBytesResponse) ProtoMessage()    {}
 func (*AddressStringToBytesResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_c451370b3929a27c, []int{13}
+	return fileDescriptor_c451370b3929a27c, []int{15}
 }
 func (m *AddressStringToBytesResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -679,7 +769,7 @@ func (m *QueryAccountAddressByIDRequest) Reset()         { *m = QueryAccountAddr
 func (m *QueryAccountAddressByIDRequest) String() string { return proto.CompactTextString(m) }
 func (*QueryAccountAddressByIDRequest) ProtoMessage()    {}
 func (*QueryAccountAddressByIDRequest) Descriptor() ([]byte, []int) {
-	return fileDescriptor_c451370b3929a27c, []int{14}
+	return fileDescriptor_c451370b3929a27c, []int{16}
 }
 func (m *QueryAccountAddressByIDRequest) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -726,7 +816,7 @@ func (m *QueryAccountAddressByIDResponse) Reset()         { *m = QueryAccountAdd
 func (m *QueryAccountAddressByIDResponse) String() string { return proto.CompactTextString(m) }
 func (*QueryAccountAddressByIDResponse) ProtoMessage()    {}
 func (*QueryAccountAddressByIDResponse) Descriptor() ([]byte, []int) {
-	return fileDescriptor_c451370b3929a27c, []int{15}
+	return fileDescriptor_c451370b3929a27c, []int{17}
 }
 func (m *QueryAccountAddressByIDResponse) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -766,11 +856,13 @@ func init() {
 	proto.RegisterType((*QueryAccountsRequest)(nil), "cosmos.auth.v1beta1.QueryAccountsRequest")
 	proto.RegisterType((*QueryAccountsResponse)(nil), "cosmos.auth.v1beta1.QueryAccountsResponse")
 	proto.RegisterType((*QueryAccountRequest)(nil), "cosmos.auth.v1beta1.QueryAccountRequest")
-	proto.RegisterType((*QueryModuleAccountsRequest)(nil), "cosmos.auth.v1beta1.QueryModuleAccountsRequest")
-	proto.RegisterType((*QueryParamsResponse)(nil), "cosmos.auth.v1beta1.QueryParamsResponse")
 	proto.RegisterType((*QueryAccountResponse)(nil), "cosmos.auth.v1beta1.QueryAccountResponse")
 	proto.RegisterType((*QueryParamsRequest)(nil), "cosmos.auth.v1beta1.QueryParamsRequest")
+	proto.RegisterType((*QueryParamsResponse)(nil), "cosmos.auth.v1beta1.QueryParamsResponse")
+	proto.RegisterType((*QueryModuleAccountsRequest)(nil), "cosmos.auth.v1beta1.QueryModuleAccountsRequest")
 	proto.RegisterType((*QueryModuleAccountsResponse)(nil), "cosmos.auth.v1beta1.QueryModuleAccountsResponse")
+	proto.RegisterType((*QueryModuleAccountByNameRequest)(nil), "cosmos.auth.v1beta1.QueryModuleAccountByNameRequest")
+	proto.RegisterType((*QueryModuleAccountByNameResponse)(nil), "cosmos.auth.v1beta1.QueryModuleAccountByNameResponse")
 	proto.RegisterType((*Bech32PrefixRequest)(nil), "cosmos.auth.v1beta1.Bech32PrefixRequest")
 	proto.RegisterType((*Bech32PrefixResponse)(nil), "cosmos.auth.v1beta1.Bech32PrefixResponse")
 	proto.RegisterType((*AddressBytesToStringRequest)(nil), "cosmos.auth.v1beta1.AddressBytesToStringRequest")
@@ -784,63 +876,67 @@ func init() {
 func init() { proto.RegisterFile("cosmos/auth/v1beta1/query.proto", fileDescriptor_c451370b3929a27c) }
 
 var fileDescriptor_c451370b3929a27c = []byte{
-	// 886 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x95, 0xcf, 0x4e, 0xeb, 0x46,
-	0x14, 0xc6, 0xe3, 0xdc, 0x16, 0xb8, 0x73, 0x73, 0x53, 0x69, 0xc8, 0x95, 0xa8, 0xc3, 0x75, 0xae,
-	0x4c, 0x81, 0x84, 0x12, 0x1b, 0x12, 0x36, 0xfd, 0xa3, 0x4a, 0x09, 0xb4, 0x15, 0x8b, 0x4a, 0xa9,
-	0x61, 0xd5, 0x45, 0x23, 0x3b, 0x36, 0xc6, 0x2a, 0xf1, 0x84, 0x8c, 0x53, 0x11, 0xa1, 0x48, 0x55,
-	0x57, 0xec, 0x5a, 0xa9, 0x2f, 0x40, 0xdf, 0xa0, 0x95, 0x78, 0x08, 0xc4, 0x0a, 0xb5, 0x9b, 0xae,
-	0xaa, 0x0a, 0xba, 0xe8, 0xb2, 0x8f, 0x70, 0x95, 0x99, 0x63, 0x27, 0x86, 0x49, 0x62, 0x56, 0xb1,
-	0x67, 0xce, 0xf9, 0xce, 0x6f, 0xce, 0x19, 0x7f, 0x41, 0x85, 0x16, 0xa1, 0x6d, 0x42, 0x75, 0xb3,
-	0x17, 0x1c, 0xeb, 0xdf, 0x6f, 0x5b, 0x4e, 0x60, 0x6e, 0xeb, 0xa7, 0x3d, 0xa7, 0xdb, 0xd7, 0x3a,
-	0x5d, 0x12, 0x10, 0xbc, 0xc8, 0x03, 0xb4, 0x61, 0x80, 0x06, 0x01, 0xf2, 0x06, 0x64, 0x59, 0x26,
-	0x75, 0x78, 0x74, 0x94, 0xdb, 0x31, 0x5d, 0xcf, 0x37, 0x03, 0x8f, 0xf8, 0x5c, 0x40, 0xce, 0xb9,
-	0xc4, 0x25, 0xec, 0x51, 0x1f, 0x3e, 0xc1, 0xea, 0xfb, 0x2e, 0x21, 0xee, 0x89, 0xa3, 0xb3, 0x37,
-	0xab, 0x77, 0xa4, 0x9b, 0x3e, 0x54, 0x94, 0x97, 0x61, 0xcb, 0xec, 0x78, 0xba, 0xe9, 0xfb, 0x24,
-	0x60, 0x6a, 0x14, 0x76, 0x15, 0x11, 0x30, 0x83, 0x03, 0x61, 0xbe, 0xdf, 0xe4, 0x15, 0x01, 0x9e,
-	0xbd, 0xa8, 0xdf, 0xa2, 0xdc, 0xd7, 0x43, 0xd6, 0x5a, 0xab, 0x45, 0x7a, 0x7e, 0x40, 0x0d, 0xe7,
-	0xb4, 0xe7, 0xd0, 0x00, 0x7f, 0x81, 0xd0, 0x88, 0x7a, 0x49, 0x7a, 0x23, 0x15, 0x5f, 0x54, 0xd6,
-	0x34, 0x48, 0x1d, 0x1e, 0x51, 0xe3, 0x0d, 0x81, 0x6a, 0x5a, 0xc3, 0x74, 0x1d, 0xc8, 0x35, 0xc6,
-	0x32, 0xd5, 0x4b, 0x09, 0xbd, 0x7a, 0x50, 0x80, 0x76, 0x88, 0x4f, 0x1d, 0xfc, 0x19, 0x5a, 0x30,
-	0x61, 0x6d, 0x49, 0x7a, 0xf3, 0xac, 0xf8, 0xa2, 0x92, 0xd3, 0xf8, 0x29, 0xb5, 0xb0, 0x01, 0x5a,
-	0xcd, 0xef, 0xd7, 0x33, 0x37, 0x57, 0xe5, 0x05, 0xc8, 0xde, 0x37, 0xa2, 0x1c, 0xfc, 0x65, 0x8c,
-	0x30, 0xcd, 0x08, 0xd7, 0x67, 0x12, 0xf2, 0xe2, 0x31, 0xc4, 0x03, 0xb4, 0x38, 0x4e, 0x18, 0x76,
-	0xa0, 0x82, 0xe6, 0x4d, 0xdb, 0xee, 0x3a, 0x94, 0xb2, 0xe3, 0x3f, 0xaf, 0x2f, 0xfd, 0x71, 0x55,
-	0xce, 0x81, 0x7e, 0x8d, 0xef, 0x1c, 0x04, 0x5d, 0xcf, 0x77, 0x8d, 0x30, 0xf0, 0xe3, 0x85, 0x8b,
-	0xcb, 0x42, 0xea, 0xbf, 0xcb, 0x42, 0x4a, 0x5d, 0x46, 0x32, 0x13, 0xfd, 0x8a, 0xd8, 0xbd, 0x13,
-	0xe7, 0x41, 0x77, 0xd5, 0x06, 0x94, 0x6c, 0x98, 0x5d, 0xb3, 0x3d, 0x6a, 0xc9, 0x47, 0x68, 0xae,
-	0xc3, 0x56, 0xa0, 0xe1, 0x79, 0x4d, 0x70, 0xd1, 0x34, 0x9e, 0x54, 0x7f, 0xe7, 0xfa, 0xef, 0x42,
-	0xca, 0x80, 0x04, 0xf5, 0x30, 0x3e, 0xc7, 0x48, 0xf2, 0x53, 0x34, 0x0f, 0x1d, 0x03, 0xcd, 0x24,
-	0x4d, 0x0e, 0x53, 0xd4, 0x1c, 0xc2, 0x31, 0x4e, 0x4e, 0xdf, 0x42, 0x79, 0xe1, 0xd9, 0xa0, 0xe4,
-	0x5e, 0xc2, 0xc1, 0xe2, 0x9b, 0xab, 0x72, 0x36, 0xa6, 0x31, 0x36, 0x5e, 0xf5, 0x15, 0x5a, 0xac,
-	0x3b, 0xad, 0xe3, 0x6a, 0xa5, 0xd1, 0x75, 0x8e, 0xbc, 0xb3, 0xb0, 0xf6, 0x27, 0x28, 0x17, 0x5f,
-	0x86, 0xa2, 0x2b, 0xe8, 0xa5, 0xc5, 0xd6, 0x9b, 0x1d, 0xb6, 0xc1, 0x67, 0x66, 0x64, 0xac, 0xb1,
-	0x60, 0xb5, 0x8e, 0xf2, 0x30, 0xb8, 0x7a, 0x3f, 0x70, 0xe8, 0x21, 0x81, 0xf9, 0xc1, 0xc4, 0x57,
-	0xd0, 0x4b, 0x18, 0x64, 0xd3, 0x1a, 0xee, 0x33, 0x8d, 0x8c, 0x91, 0x31, 0xc7, 0x72, 0xd4, 0xcf,
-	0xd1, 0xb2, 0x58, 0x03, 0x40, 0x56, 0x51, 0x36, 0x14, 0xa1, 0x6c, 0x07, 0x48, 0x42, 0x69, 0x1e,
-	0xae, 0xee, 0x45, 0x28, 0x7c, 0xe1, 0x90, 0x30, 0xb9, 0x10, 0x25, 0xa1, 0xca, 0x6e, 0x04, 0xf3,
-	0x40, 0x65, 0xd4, 0x95, 0xd9, 0x27, 0xda, 0x42, 0xca, 0xf8, 0xd5, 0x89, 0x4e, 0xb7, 0xbf, 0x17,
-	0xd2, 0x64, 0x51, 0xda, 0xb3, 0x59, 0xee, 0x33, 0x23, 0xed, 0xd9, 0xaa, 0x8d, 0x0a, 0x13, 0x33,
-	0xa0, 0x72, 0x0d, 0xbd, 0x07, 0xa3, 0x6c, 0x26, 0xfd, 0x8a, 0xb2, 0x66, 0x4c, 0xae, 0xf2, 0xff,
-	0x73, 0xf4, 0x2e, 0x2b, 0x83, 0x2f, 0x24, 0x14, 0x5e, 0x4e, 0x8a, 0x4b, 0xc2, 0x8f, 0x42, 0x64,
-	0x62, 0xf2, 0x46, 0x92, 0x50, 0x0e, 0xac, 0xae, 0xfe, 0xf8, 0xe7, 0xbf, 0xbf, 0xa4, 0x0b, 0xf8,
-	0xb5, 0x2e, 0x34, 0xd3, 0xb0, 0xfa, 0x4f, 0x12, 0x9a, 0x87, 0x5c, 0x5c, 0x9c, 0x29, 0x1f, 0x82,
-	0x94, 0x12, 0x44, 0x02, 0x87, 0xce, 0x38, 0x4a, 0x78, 0x7d, 0x2a, 0x87, 0x7e, 0x0e, 0x5d, 0x1d,
-	0xe0, 0xdf, 0x24, 0x84, 0x1f, 0x0f, 0x02, 0x57, 0x67, 0x96, 0x7c, 0x3c, 0x68, 0x79, 0xe7, 0x69,
-	0x49, 0xc9, 0x90, 0xa3, 0x0b, 0xd8, 0xf4, 0x6c, 0xfd, 0xdc, 0xb3, 0x07, 0xf8, 0x07, 0x09, 0xcd,
-	0x71, 0x4b, 0xc1, 0xeb, 0x93, 0x2b, 0xc6, 0x4c, 0x47, 0x2e, 0xce, 0x0e, 0x04, 0x9c, 0x15, 0x86,
-	0xf3, 0x1a, 0xe7, 0x85, 0x38, 0xdc, 0x2f, 0xf1, 0xaf, 0x12, 0x8a, 0x7b, 0x0f, 0xc5, 0xfa, 0xe4,
-	0x0a, 0x42, 0x17, 0x97, 0xb7, 0x92, 0x27, 0x00, 0xda, 0x26, 0x43, 0x5b, 0xc3, 0x1f, 0x08, 0xd1,
-	0xda, 0x2c, 0xa9, 0x19, 0xdd, 0xb5, 0x0b, 0x09, 0x65, 0xc6, 0xcd, 0x6e, 0xc2, 0x85, 0x13, 0xd8,
-	0xe4, 0x84, 0x0b, 0x27, 0x72, 0xce, 0x19, 0xed, 0xe2, 0xfe, 0x39, 0xbc, 0x64, 0x39, 0x91, 0xed,
-	0x61, 0x71, 0x0f, 0xa6, 0xb8, 0xac, 0xbc, 0xfd, 0x84, 0x0c, 0x40, 0xac, 0x32, 0xc4, 0x32, 0xfe,
-	0x70, 0x0a, 0x62, 0xf4, 0x45, 0x70, 0xa7, 0x1b, 0xe0, 0xdf, 0x47, 0xc8, 0x31, 0x73, 0x9c, 0x8e,
-	0x2c, 0x72, 0xe3, 0xe9, 0xc8, 0x42, 0xe7, 0x55, 0x77, 0x18, 0xb2, 0x86, 0x37, 0x13, 0x21, 0x73,
-	0x8f, 0x1f, 0xd4, 0x77, 0xaf, 0xef, 0x14, 0xe9, 0xf6, 0x4e, 0x91, 0xfe, 0xb9, 0x53, 0xa4, 0x9f,
-	0xef, 0x95, 0xd4, 0xed, 0xbd, 0x92, 0xfa, 0xeb, 0x5e, 0x49, 0x7d, 0x53, 0x72, 0xbd, 0xe0, 0xb8,
-	0x67, 0x69, 0x2d, 0xd2, 0x0e, 0x15, 0xf9, 0x4f, 0x99, 0xda, 0xdf, 0xe9, 0x67, 0x5c, 0x3e, 0xe8,
-	0x77, 0x1c, 0x6a, 0xcd, 0xb1, 0x7f, 0xd9, 0xea, 0xdb, 0x00, 0x00, 0x00, 0xff, 0xff, 0x7a, 0x78,
-	0xb2, 0xf3, 0xc7, 0x0a, 0x00, 0x00,
+	// 956 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x94, 0x96, 0xcf, 0x4f, 0x1b, 0x47,
+	0x14, 0xc7, 0xbd, 0x24, 0x05, 0xfa, 0x70, 0xa8, 0x34, 0x38, 0x12, 0x5d, 0x88, 0x8d, 0x96, 0x26,
+	0x40, 0x1a, 0xef, 0x06, 0x43, 0x0e, 0xfd, 0xa1, 0x4a, 0x6c, 0x68, 0xab, 0x1c, 0x5a, 0x51, 0x87,
+	0x53, 0x0f, 0xb5, 0xc6, 0xde, 0x65, 0x59, 0x35, 0xde, 0x71, 0x3c, 0xeb, 0x2a, 0x16, 0xb2, 0x54,
+	0xf5, 0x94, 0x5b, 0x2b, 0xf5, 0x1f, 0xa0, 0xd7, 0x9e, 0x5a, 0x09, 0xa9, 0xff, 0x42, 0x94, 0x13,
+	0x6a, 0x2f, 0x3d, 0x55, 0x15, 0xf4, 0xd0, 0x3f, 0x23, 0xda, 0x99, 0x37, 0x8b, 0x17, 0xc6, 0xf6,
+	0x72, 0x62, 0x3d, 0xf3, 0xbe, 0xef, 0x7d, 0xde, 0xbc, 0x79, 0x6f, 0x80, 0x4a, 0x8b, 0xf1, 0x36,
+	0xe3, 0x0e, 0xed, 0xc5, 0x87, 0xce, 0x77, 0x9b, 0x4d, 0x3f, 0xa6, 0x9b, 0xce, 0xf3, 0x9e, 0xdf,
+	0xed, 0xdb, 0x9d, 0x2e, 0x8b, 0x19, 0x59, 0x90, 0x06, 0x76, 0x62, 0x60, 0xa3, 0x81, 0x79, 0x1f,
+	0x55, 0x4d, 0xca, 0x7d, 0x69, 0x9d, 0x6a, 0x3b, 0x34, 0x08, 0x23, 0x1a, 0x87, 0x2c, 0x92, 0x0e,
+	0xcc, 0x52, 0xc0, 0x02, 0x26, 0x3e, 0x9d, 0xe4, 0x0b, 0x57, 0xdf, 0x0d, 0x18, 0x0b, 0x9e, 0xf9,
+	0x8e, 0xf8, 0xd5, 0xec, 0x1d, 0x38, 0x34, 0xc2, 0x88, 0xe6, 0x32, 0x6e, 0xd1, 0x4e, 0xe8, 0xd0,
+	0x28, 0x62, 0xb1, 0xf0, 0xc6, 0x71, 0xb7, 0xac, 0x03, 0x16, 0x70, 0xe8, 0x58, 0xee, 0x37, 0x64,
+	0x44, 0x84, 0x17, 0x3f, 0xac, 0x6f, 0xa0, 0xf4, 0x55, 0xc2, 0xba, 0xd3, 0x6a, 0xb1, 0x5e, 0x14,
+	0xf3, 0xba, 0xff, 0xbc, 0xe7, 0xf3, 0x98, 0x7c, 0x06, 0x70, 0x41, 0xbd, 0x68, 0xac, 0x18, 0xeb,
+	0x73, 0xb5, 0x7b, 0x36, 0x4a, 0x93, 0x14, 0x6d, 0x79, 0x20, 0x18, 0xcd, 0xde, 0xa3, 0x81, 0x8f,
+	0xda, 0xfa, 0x90, 0xd2, 0x3a, 0x36, 0xe0, 0xf6, 0xa5, 0x00, 0xbc, 0xc3, 0x22, 0xee, 0x93, 0x4f,
+	0x60, 0x96, 0xe2, 0xda, 0xa2, 0xb1, 0x72, 0x63, 0x7d, 0xae, 0x56, 0xb2, 0x65, 0x96, 0xb6, 0x3a,
+	0x00, 0x7b, 0x27, 0xea, 0xbb, 0xc5, 0xd7, 0x27, 0xd5, 0x59, 0x54, 0x3f, 0xa9, 0xa7, 0x1a, 0xf2,
+	0x79, 0x86, 0x70, 0x4a, 0x10, 0xae, 0x4d, 0x24, 0x94, 0xc1, 0x33, 0x88, 0x4f, 0x61, 0x61, 0x98,
+	0x50, 0x9d, 0x40, 0x0d, 0x66, 0xa8, 0xe7, 0x75, 0x7d, 0xce, 0x45, 0xfa, 0x6f, 0xbb, 0x8b, 0x7f,
+	0x9e, 0x54, 0x4b, 0xe8, 0x7f, 0x47, 0xee, 0x3c, 0x8d, 0xbb, 0x61, 0x14, 0xd4, 0x95, 0xe1, 0x87,
+	0xb3, 0x2f, 0x8f, 0x2b, 0x85, 0xff, 0x8f, 0x2b, 0x05, 0x6b, 0x3f, 0x7b, 0xae, 0x69, 0xd6, 0x1f,
+	0xc3, 0x0c, 0x66, 0x80, 0x87, 0x9a, 0x27, 0x69, 0x25, 0xb1, 0x4a, 0x40, 0x84, 0xd7, 0x3d, 0xda,
+	0xa5, 0x6d, 0x55, 0x2b, 0x6b, 0x0f, 0x13, 0x50, 0xab, 0x18, 0xea, 0x03, 0x98, 0xee, 0x88, 0x15,
+	0x8c, 0xb4, 0x64, 0x6b, 0xae, 0xad, 0x2d, 0x45, 0xee, 0xcd, 0x57, 0xff, 0x54, 0x0a, 0x75, 0x14,
+	0x58, 0xcb, 0x60, 0x0a, 0x8f, 0x5f, 0x30, 0xaf, 0xf7, 0xcc, 0xbf, 0x74, 0x37, 0xac, 0x16, 0x2c,
+	0x69, 0x77, 0x31, 0xee, 0x6e, 0xce, 0xc2, 0x92, 0xd7, 0x27, 0xd5, 0xf9, 0x8c, 0x8f, 0xa1, 0xf2,
+	0x5a, 0x8f, 0xa0, 0x72, 0x35, 0x88, 0xdb, 0xff, 0x92, 0xb6, 0xd5, 0x3d, 0x23, 0x04, 0x6e, 0x46,
+	0xb4, 0xed, 0xcb, 0xf2, 0xd4, 0xc5, 0xb7, 0x75, 0x00, 0x2b, 0xa3, 0x65, 0x08, 0xe8, 0xe6, 0xab,
+	0x81, 0x8e, 0x2f, 0xad, 0xc4, 0x6d, 0x58, 0x70, 0xfd, 0xd6, 0xe1, 0x56, 0x6d, 0xaf, 0xeb, 0x1f,
+	0x84, 0x2f, 0xd4, 0xd1, 0x7c, 0x04, 0xa5, 0xec, 0x32, 0x86, 0x5c, 0x85, 0x5b, 0x4d, 0xb1, 0xde,
+	0xe8, 0x88, 0x0d, 0x64, 0x2e, 0x36, 0x87, 0x8c, 0x2d, 0x17, 0x96, 0xf0, 0x5e, 0xb9, 0xfd, 0xd8,
+	0xe7, 0xfb, 0x0c, 0xaf, 0x17, 0xa6, 0xbb, 0x0a, 0xb7, 0xf0, 0x9e, 0x35, 0x9a, 0xc9, 0xbe, 0xf0,
+	0x51, 0xac, 0x17, 0xe9, 0x90, 0xc6, 0xfa, 0x14, 0x96, 0xf5, 0x3e, 0x10, 0xe4, 0x2e, 0xcc, 0x2b,
+	0x27, 0x5c, 0xec, 0x20, 0x89, 0x72, 0x2d, 0xcd, 0xad, 0xdd, 0x14, 0x45, 0x2e, 0xec, 0x33, 0xe1,
+	0x4e, 0xa1, 0xe4, 0xf4, 0xf2, 0x38, 0x85, 0xb9, 0xe4, 0xe5, 0xe2, 0x54, 0x26, 0x67, 0xf4, 0x10,
+	0xca, 0xc3, 0x9d, 0x94, 0x66, 0xf7, 0x64, 0x57, 0xd1, 0xcc, 0xc3, 0x54, 0xe8, 0x09, 0xed, 0x8d,
+	0xfa, 0x54, 0xe8, 0x59, 0x1e, 0x5e, 0x1d, 0x9d, 0x02, 0x23, 0xef, 0xc0, 0x3b, 0x58, 0xc9, 0x46,
+	0xde, 0x26, 0x9f, 0xa7, 0x19, 0x77, 0xb5, 0x5f, 0xe7, 0xe0, 0x2d, 0x11, 0x86, 0xbc, 0x34, 0x40,
+	0xf5, 0x2a, 0x27, 0x1b, 0xda, 0x2e, 0xd3, 0xcd, 0x58, 0xf3, 0x7e, 0x1e, 0x53, 0x09, 0x6c, 0xdd,
+	0xfd, 0xe1, 0xaf, 0xff, 0x7e, 0x9e, 0xaa, 0x90, 0x3b, 0x8e, 0x76, 0xd6, 0xab, 0xe8, 0x3f, 0x1a,
+	0x30, 0x83, 0x5a, 0xb2, 0x3e, 0xd1, 0xbd, 0x02, 0xd9, 0xc8, 0x61, 0x89, 0x1c, 0x8e, 0xe0, 0xd8,
+	0x20, 0x6b, 0x63, 0x39, 0x9c, 0x23, 0x3c, 0xd5, 0x01, 0xf9, 0xcd, 0x00, 0x72, 0xb5, 0x10, 0x64,
+	0x6b, 0x62, 0xc8, 0xab, 0x85, 0x36, 0xb7, 0xaf, 0x27, 0xca, 0x87, 0x9c, 0x5e, 0xc0, 0x46, 0xe8,
+	0x39, 0x47, 0xa1, 0x37, 0x20, 0xdf, 0x1b, 0x30, 0x2d, 0xc7, 0x22, 0x59, 0x1b, 0x1d, 0x31, 0x33,
+	0x83, 0xcd, 0xf5, 0xc9, 0x86, 0x88, 0xb3, 0x2a, 0x70, 0xee, 0x90, 0x25, 0x2d, 0x8e, 0x1c, 0xc0,
+	0xe4, 0x17, 0x03, 0xb2, 0xa3, 0x87, 0x13, 0x67, 0x74, 0x04, 0xed, 0x98, 0x36, 0x1f, 0xe6, 0x17,
+	0x20, 0xda, 0x03, 0x81, 0x76, 0x8f, 0xbc, 0xa7, 0x45, 0x6b, 0x0b, 0x51, 0x23, 0xbd, 0x6b, 0x7f,
+	0x18, 0xb0, 0xa0, 0x19, 0xb3, 0x64, 0x3b, 0x67, 0xdc, 0xcc, 0x30, 0x37, 0x1f, 0x5d, 0x53, 0x85,
+	0xc8, 0x5b, 0x02, 0xb9, 0x4a, 0xde, 0xcf, 0x83, 0xec, 0x1c, 0x25, 0x6f, 0xc4, 0x20, 0x69, 0xd8,
+	0xe2, 0xf0, 0x98, 0x1e, 0xd1, 0x2a, 0x9a, 0x01, 0x3f, 0xa2, 0x55, 0x74, 0x33, 0x7f, 0x42, 0xa1,
+	0xe5, 0xe4, 0x4f, 0xda, 0xa3, 0xa4, 0x1b, 0xd8, 0x44, 0x5f, 0xbd, 0x31, 0xef, 0x83, 0xb9, 0x79,
+	0x0d, 0x45, 0xae, 0xd3, 0x93, 0x88, 0x69, 0x2f, 0xcb, 0x19, 0x3d, 0x20, 0xbf, 0x5f, 0x20, 0x67,
+	0xc6, 0xfa, 0x78, 0x64, 0xdd, 0x3b, 0x32, 0x1e, 0x59, 0xfb, 0x66, 0x58, 0xdb, 0x02, 0xd9, 0x26,
+	0x0f, 0x72, 0x21, 0xcb, 0xd7, 0x69, 0xe0, 0x3e, 0x7e, 0x75, 0x56, 0x36, 0x4e, 0xcf, 0xca, 0xc6,
+	0xbf, 0x67, 0x65, 0xe3, 0xa7, 0xf3, 0x72, 0xe1, 0xf4, 0xbc, 0x5c, 0xf8, 0xfb, 0xbc, 0x5c, 0xf8,
+	0x7a, 0x23, 0x08, 0xe3, 0xc3, 0x5e, 0xd3, 0x6e, 0xb1, 0xb6, 0xf2, 0x28, 0xff, 0x54, 0xb9, 0xf7,
+	0xad, 0xf3, 0x42, 0xba, 0x8f, 0xfb, 0x1d, 0x9f, 0x37, 0xa7, 0xc5, 0xbf, 0x07, 0x5b, 0x6f, 0x02,
+	0x00, 0x00, 0xff, 0xff, 0xfd, 0xbf, 0xbf, 0x8e, 0x20, 0x0c, 0x00, 0x00,
 }
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -871,6 +967,8 @@ type QueryClient interface {
 	//
 	// Since: cosmos-sdk 0.46
 	ModuleAccounts(ctx context.Context, in *QueryModuleAccountsRequest, opts ...grpc.CallOption) (*QueryModuleAccountsResponse, error)
+	// ModuleAccountByName returns the module account info by module name
+	ModuleAccountByName(ctx context.Context, in *QueryModuleAccountByNameRequest, opts ...grpc.CallOption) (*QueryModuleAccountByNameResponse, error)
 	// Bech32Prefix queries bech32Prefix
 	//
 	// Since: cosmos-sdk 0.46
@@ -938,6 +1036,15 @@ func (c *queryClient) ModuleAccounts(ctx context.Context, in *QueryModuleAccount
 	return out, nil
 }
 
+func (c *queryClient) ModuleAccountByName(ctx context.Context, in *QueryModuleAccountByNameRequest, opts ...grpc.CallOption) (*QueryModuleAccountByNameResponse, error) {
+	out := new(QueryModuleAccountByNameResponse)
+	err := c.cc.Invoke(ctx, "/cosmos.auth.v1beta1.Query/ModuleAccountByName", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *queryClient) Bech32Prefix(ctx context.Context, in *Bech32PrefixRequest, opts ...grpc.CallOption) (*Bech32PrefixResponse, error) {
 	out := new(Bech32PrefixResponse)
 	err := c.cc.Invoke(ctx, "/cosmos.auth.v1beta1.Query/Bech32Prefix", in, out, opts...)
@@ -983,6 +1090,8 @@ type QueryServer interface {
 	//
 	// Since: cosmos-sdk 0.46
 	ModuleAccounts(context.Context, *QueryModuleAccountsRequest) (*QueryModuleAccountsResponse, error)
+	// ModuleAccountByName returns the module account info by module name
+	ModuleAccountByName(context.Context, *QueryModuleAccountByNameRequest) (*QueryModuleAccountByNameResponse, error)
 	// Bech32Prefix queries bech32Prefix
 	//
 	// Since: cosmos-sdk 0.46
@@ -1015,6 +1124,9 @@ func (*UnimplementedQueryServer) Params(ctx context.Context, req *QueryParamsReq
 }
 func (*UnimplementedQueryServer) ModuleAccounts(ctx context.Context, req *QueryModuleAccountsRequest) (*QueryModuleAccountsResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ModuleAccounts not implemented")
+}
+func (*UnimplementedQueryServer) ModuleAccountByName(ctx context.Context, req *QueryModuleAccountByNameRequest) (*QueryModuleAccountByNameResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ModuleAccountByName not implemented")
 }
 func (*UnimplementedQueryServer) Bech32Prefix(ctx context.Context, req *Bech32PrefixRequest) (*Bech32PrefixResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method Bech32Prefix not implemented")
@@ -1120,6 +1232,24 @@ func _Query_ModuleAccounts_Handler(srv interface{}, ctx context.Context, dec fun
 	return interceptor(ctx, in, info, handler)
 }
 
+func _Query_ModuleAccountByName_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(QueryModuleAccountByNameRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(QueryServer).ModuleAccountByName(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/cosmos.auth.v1beta1.Query/ModuleAccountByName",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(QueryServer).ModuleAccountByName(ctx, req.(*QueryModuleAccountByNameRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _Query_Bech32Prefix_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(Bech32PrefixRequest)
 	if err := dec(in); err != nil {
@@ -1197,6 +1327,10 @@ var _Query_serviceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ModuleAccounts",
 			Handler:    _Query_ModuleAccounts_Handler,
+		},
+		{
+			MethodName: "ModuleAccountByName",
+			Handler:    _Query_ModuleAccountByName_Handler,
 		},
 		{
 			MethodName: "Bech32Prefix",
@@ -1329,62 +1463,6 @@ func (m *QueryAccountRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
-func (m *QueryModuleAccountsRequest) Marshal() (dAtA []byte, err error) {
-	size := m.Size()
-	dAtA = make([]byte, size)
-	n, err := m.MarshalToSizedBuffer(dAtA[:size])
-	if err != nil {
-		return nil, err
-	}
-	return dAtA[:n], nil
-}
-
-func (m *QueryModuleAccountsRequest) MarshalTo(dAtA []byte) (int, error) {
-	size := m.Size()
-	return m.MarshalToSizedBuffer(dAtA[:size])
-}
-
-func (m *QueryModuleAccountsRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
-	i := len(dAtA)
-	_ = i
-	var l int
-	_ = l
-	return len(dAtA) - i, nil
-}
-
-func (m *QueryParamsResponse) Marshal() (dAtA []byte, err error) {
-	size := m.Size()
-	dAtA = make([]byte, size)
-	n, err := m.MarshalToSizedBuffer(dAtA[:size])
-	if err != nil {
-		return nil, err
-	}
-	return dAtA[:n], nil
-}
-
-func (m *QueryParamsResponse) MarshalTo(dAtA []byte) (int, error) {
-	size := m.Size()
-	return m.MarshalToSizedBuffer(dAtA[:size])
-}
-
-func (m *QueryParamsResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
-	i := len(dAtA)
-	_ = i
-	var l int
-	_ = l
-	{
-		size, err := m.Params.MarshalToSizedBuffer(dAtA[:i])
-		if err != nil {
-			return 0, err
-		}
-		i -= size
-		i = encodeVarintQuery(dAtA, i, uint64(size))
-	}
-	i--
-	dAtA[i] = 0xa
-	return len(dAtA) - i, nil
-}
-
 func (m *QueryAccountResponse) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
@@ -1443,6 +1521,62 @@ func (m *QueryParamsRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *QueryParamsResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *QueryParamsResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *QueryParamsResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	{
+		size, err := m.Params.MarshalToSizedBuffer(dAtA[:i])
+		if err != nil {
+			return 0, err
+		}
+		i -= size
+		i = encodeVarintQuery(dAtA, i, uint64(size))
+	}
+	i--
+	dAtA[i] = 0xa
+	return len(dAtA) - i, nil
+}
+
+func (m *QueryModuleAccountsRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *QueryModuleAccountsRequest) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *QueryModuleAccountsRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	return len(dAtA) - i, nil
+}
+
 func (m *QueryModuleAccountsResponse) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
@@ -1476,6 +1610,71 @@ func (m *QueryModuleAccountsResponse) MarshalToSizedBuffer(dAtA []byte) (int, er
 			i--
 			dAtA[i] = 0xa
 		}
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *QueryModuleAccountByNameRequest) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *QueryModuleAccountByNameRequest) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *QueryModuleAccountByNameRequest) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.Name) > 0 {
+		i -= len(m.Name)
+		copy(dAtA[i:], m.Name)
+		i = encodeVarintQuery(dAtA, i, uint64(len(m.Name)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
+func (m *QueryModuleAccountByNameResponse) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *QueryModuleAccountByNameResponse) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *QueryModuleAccountByNameResponse) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if m.Account != nil {
+		{
+			size, err := m.Account.MarshalToSizedBuffer(dAtA[:i])
+			if err != nil {
+				return 0, err
+			}
+			i -= size
+			i = encodeVarintQuery(dAtA, i, uint64(size))
+		}
+		i--
+		dAtA[i] = 0xa
 	}
 	return len(dAtA) - i, nil
 }
@@ -1767,26 +1966,6 @@ func (m *QueryAccountRequest) Size() (n int) {
 	return n
 }
 
-func (m *QueryModuleAccountsRequest) Size() (n int) {
-	if m == nil {
-		return 0
-	}
-	var l int
-	_ = l
-	return n
-}
-
-func (m *QueryParamsResponse) Size() (n int) {
-	if m == nil {
-		return 0
-	}
-	var l int
-	_ = l
-	l = m.Params.Size()
-	n += 1 + l + sovQuery(uint64(l))
-	return n
-}
-
 func (m *QueryAccountResponse) Size() (n int) {
 	if m == nil {
 		return 0
@@ -1809,6 +1988,26 @@ func (m *QueryParamsRequest) Size() (n int) {
 	return n
 }
 
+func (m *QueryParamsResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = m.Params.Size()
+	n += 1 + l + sovQuery(uint64(l))
+	return n
+}
+
+func (m *QueryModuleAccountsRequest) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	return n
+}
+
 func (m *QueryModuleAccountsResponse) Size() (n int) {
 	if m == nil {
 		return 0
@@ -1820,6 +2019,32 @@ func (m *QueryModuleAccountsResponse) Size() (n int) {
 			l = e.Size()
 			n += 1 + l + sovQuery(uint64(l))
 		}
+	}
+	return n
+}
+
+func (m *QueryModuleAccountByNameRequest) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.Name)
+	if l > 0 {
+		n += 1 + l + sovQuery(uint64(l))
+	}
+	return n
+}
+
+func (m *QueryModuleAccountByNameResponse) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	if m.Account != nil {
+		l = m.Account.Size()
+		n += 1 + l + sovQuery(uint64(l))
 	}
 	return n
 }
@@ -2217,139 +2442,6 @@ func (m *QueryAccountRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
-func (m *QueryModuleAccountsRequest) Unmarshal(dAtA []byte) error {
-	l := len(dAtA)
-	iNdEx := 0
-	for iNdEx < l {
-		preIndex := iNdEx
-		var wire uint64
-		for shift := uint(0); ; shift += 7 {
-			if shift >= 64 {
-				return ErrIntOverflowQuery
-			}
-			if iNdEx >= l {
-				return io.ErrUnexpectedEOF
-			}
-			b := dAtA[iNdEx]
-			iNdEx++
-			wire |= uint64(b&0x7F) << shift
-			if b < 0x80 {
-				break
-			}
-		}
-		fieldNum := int32(wire >> 3)
-		wireType := int(wire & 0x7)
-		if wireType == 4 {
-			return fmt.Errorf("proto: QueryModuleAccountsRequest: wiretype end group for non-group")
-		}
-		if fieldNum <= 0 {
-			return fmt.Errorf("proto: QueryModuleAccountsRequest: illegal tag %d (wire type %d)", fieldNum, wire)
-		}
-		switch fieldNum {
-		default:
-			iNdEx = preIndex
-			skippy, err := skipQuery(dAtA[iNdEx:])
-			if err != nil {
-				return err
-			}
-			if (skippy < 0) || (iNdEx+skippy) < 0 {
-				return ErrInvalidLengthQuery
-			}
-			if (iNdEx + skippy) > l {
-				return io.ErrUnexpectedEOF
-			}
-			iNdEx += skippy
-		}
-	}
-
-	if iNdEx > l {
-		return io.ErrUnexpectedEOF
-	}
-	return nil
-}
-func (m *QueryParamsResponse) Unmarshal(dAtA []byte) error {
-	l := len(dAtA)
-	iNdEx := 0
-	for iNdEx < l {
-		preIndex := iNdEx
-		var wire uint64
-		for shift := uint(0); ; shift += 7 {
-			if shift >= 64 {
-				return ErrIntOverflowQuery
-			}
-			if iNdEx >= l {
-				return io.ErrUnexpectedEOF
-			}
-			b := dAtA[iNdEx]
-			iNdEx++
-			wire |= uint64(b&0x7F) << shift
-			if b < 0x80 {
-				break
-			}
-		}
-		fieldNum := int32(wire >> 3)
-		wireType := int(wire & 0x7)
-		if wireType == 4 {
-			return fmt.Errorf("proto: QueryParamsResponse: wiretype end group for non-group")
-		}
-		if fieldNum <= 0 {
-			return fmt.Errorf("proto: QueryParamsResponse: illegal tag %d (wire type %d)", fieldNum, wire)
-		}
-		switch fieldNum {
-		case 1:
-			if wireType != 2 {
-				return fmt.Errorf("proto: wrong wireType = %d for field Params", wireType)
-			}
-			var msglen int
-			for shift := uint(0); ; shift += 7 {
-				if shift >= 64 {
-					return ErrIntOverflowQuery
-				}
-				if iNdEx >= l {
-					return io.ErrUnexpectedEOF
-				}
-				b := dAtA[iNdEx]
-				iNdEx++
-				msglen |= int(b&0x7F) << shift
-				if b < 0x80 {
-					break
-				}
-			}
-			if msglen < 0 {
-				return ErrInvalidLengthQuery
-			}
-			postIndex := iNdEx + msglen
-			if postIndex < 0 {
-				return ErrInvalidLengthQuery
-			}
-			if postIndex > l {
-				return io.ErrUnexpectedEOF
-			}
-			if err := m.Params.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
-				return err
-			}
-			iNdEx = postIndex
-		default:
-			iNdEx = preIndex
-			skippy, err := skipQuery(dAtA[iNdEx:])
-			if err != nil {
-				return err
-			}
-			if (skippy < 0) || (iNdEx+skippy) < 0 {
-				return ErrInvalidLengthQuery
-			}
-			if (iNdEx + skippy) > l {
-				return io.ErrUnexpectedEOF
-			}
-			iNdEx += skippy
-		}
-	}
-
-	if iNdEx > l {
-		return io.ErrUnexpectedEOF
-	}
-	return nil
-}
 func (m *QueryAccountResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2486,6 +2578,139 @@ func (m *QueryParamsRequest) Unmarshal(dAtA []byte) error {
 	}
 	return nil
 }
+func (m *QueryParamsResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: QueryParamsResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: QueryParamsResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Params", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if err := m.Params.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *QueryModuleAccountsRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: QueryModuleAccountsRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: QueryModuleAccountsRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
 func (m *QueryModuleAccountsResponse) Unmarshal(dAtA []byte) error {
 	l := len(dAtA)
 	iNdEx := 0
@@ -2546,6 +2771,174 @@ func (m *QueryModuleAccountsResponse) Unmarshal(dAtA []byte) error {
 			}
 			m.Accounts = append(m.Accounts, &types.Any{})
 			if err := m.Accounts[len(m.Accounts)-1].Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
+				return err
+			}
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *QueryModuleAccountByNameRequest) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: QueryModuleAccountByNameRequest: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: QueryModuleAccountByNameRequest: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Name", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.Name = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipQuery(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *QueryModuleAccountByNameResponse) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowQuery
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: QueryModuleAccountByNameResponse: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: QueryModuleAccountByNameResponse: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field Account", wireType)
+			}
+			var msglen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowQuery
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				msglen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if msglen < 0 {
+				return ErrInvalidLengthQuery
+			}
+			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthQuery
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			if m.Account == nil {
+				m.Account = &types.Any{}
+			}
+			if err := m.Account.Unmarshal(dAtA[iNdEx:postIndex]); err != nil {
 				return err
 			}
 			iNdEx = postIndex

--- a/x/auth/types/query.pb.gw.go
+++ b/x/auth/types/query.pb.gw.go
@@ -213,6 +213,60 @@ func local_request_Query_ModuleAccounts_0(ctx context.Context, marshaler runtime
 
 }
 
+func request_Query_ModuleAccountByName_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq QueryModuleAccountByNameRequest
+	var metadata runtime.ServerMetadata
+
+	var (
+		val string
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["name"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
+	}
+
+	protoReq.Name, err = runtime.String(val)
+
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "name", err)
+	}
+
+	msg, err := client.ModuleAccountByName(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+
+}
+
+func local_request_Query_ModuleAccountByName_0(ctx context.Context, marshaler runtime.Marshaler, server QueryServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var protoReq QueryModuleAccountByNameRequest
+	var metadata runtime.ServerMetadata
+
+	var (
+		val string
+		ok  bool
+		err error
+		_   = err
+	)
+
+	val, ok = pathParams["name"]
+	if !ok {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "missing parameter %s", "name")
+	}
+
+	protoReq.Name, err = runtime.String(val)
+
+	if err != nil {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "type mismatch, parameter: %s, error: %v", "name", err)
+	}
+
+	msg, err := server.ModuleAccountByName(ctx, &protoReq)
+	return msg, metadata, err
+
+}
+
 func request_Query_Bech32Prefix_0(ctx context.Context, marshaler runtime.Marshaler, client QueryClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var protoReq Bech32PrefixRequest
 	var metadata runtime.ServerMetadata
@@ -460,6 +514,29 @@ func RegisterQueryHandlerServer(ctx context.Context, mux *runtime.ServeMux, serv
 
 	})
 
+	mux.Handle("GET", pattern_Query_ModuleAccountByName_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateIncomingContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_Query_ModuleAccountByName_0(rctx, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Query_ModuleAccountByName_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
 	mux.Handle("GET", pattern_Query_Bech32Prefix_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -670,6 +747,26 @@ func RegisterQueryHandlerClient(ctx context.Context, mux *runtime.ServeMux, clie
 
 	})
 
+	mux.Handle("GET", pattern_Query_ModuleAccountByName_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		rctx, err := runtime.AnnotateContext(ctx, mux, req)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_Query_ModuleAccountByName_0(rctx, inboundMarshaler, client, req, pathParams)
+		ctx = runtime.NewServerMetadataContext(ctx, md)
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+
+		forward_Query_ModuleAccountByName_0(ctx, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+
+	})
+
 	mux.Handle("GET", pattern_Query_Bech32Prefix_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -744,6 +841,8 @@ var (
 
 	pattern_Query_ModuleAccounts_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"cosmos", "auth", "v1beta1", "module_accounts"}, "", runtime.AssumeColonVerbOpt(false)))
 
+	pattern_Query_ModuleAccountByName_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 1, 0, 4, 1, 5, 4}, []string{"cosmos", "auth", "v1beta1", "module_accounts", "name"}, "", runtime.AssumeColonVerbOpt(false)))
+
 	pattern_Query_Bech32Prefix_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"cosmos", "auth", "v1beta1", "bech32"}, "", runtime.AssumeColonVerbOpt(false)))
 
 	pattern_Query_AddressBytesToString_0 = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3, 1, 0, 4, 1, 5, 4}, []string{"cosmos", "auth", "v1beta1", "bech32", "address_bytes"}, "", runtime.AssumeColonVerbOpt(false)))
@@ -761,6 +860,8 @@ var (
 	forward_Query_Params_0 = runtime.ForwardResponseMessage
 
 	forward_Query_ModuleAccounts_0 = runtime.ForwardResponseMessage
+
+	forward_Query_ModuleAccountByName_0 = runtime.ForwardResponseMessage
 
 	forward_Query_Bech32Prefix_0 = runtime.ForwardResponseMessage
 

--- a/x/gov/abci.go
+++ b/x/gov/abci.go
@@ -84,12 +84,6 @@ func EndBlocker(ctx sdk.Context, keeper keeper.Keeper) {
 				tagValue = types.AttributeValueProposalPassed
 				logMsg = "passed"
 
-				// The cached context is created with a new EventManager. However, since
-				// the proposal handler execution was successful, we want to track/keep
-				// any events emitted, so we re-emit to "merge" the events into the
-				// original Context's EventManager.
-				ctx.EventManager().EmitEvents(cacheCtx.EventManager().Events())
-
 				// write state to the underlying multi-store
 				writeCache()
 			} else {

--- a/x/group/keeper/msg_server.go
+++ b/x/group/keeper/msg_server.go
@@ -754,19 +754,13 @@ func (k Keeper) Exec(goCtx context.Context, req *group.MsgExec) (*group.MsgExecR
 			return nil, err
 		}
 
-		results, err := k.doExecuteMsgs(cacheCtx, k.router, proposal, addr)
-		if err != nil {
+		if _, err := k.doExecuteMsgs(cacheCtx, k.router, proposal, addr); err != nil {
 			proposal.ExecutorResult = group.PROPOSAL_EXECUTOR_RESULT_FAILURE
 			logs = fmt.Sprintf("proposal execution failed on proposal %d, because of error %s", id, err.Error())
 			k.Logger(ctx).Info("proposal execution failed", "cause", err, "proposalID", id)
 		} else {
 			proposal.ExecutorResult = group.PROPOSAL_EXECUTOR_RESULT_SUCCESS
 			flush()
-
-			for _, res := range results {
-				// NOTE: The sdk msg handler creates a new EventManager, so events must be correctly propagated back to the current context
-				ctx.EventManager().EmitEvents(res.GetEvents())
-			}
 		}
 	}
 


### PR DESCRIPTION
## Description

This PR does the following:
* Brings the v0.46.4 changes into our own v0.46.x branch.
* Changes the default for the `--iavl-disable-fastnode` flag (on the `start` command) to `true` (from `false`) to match the default we defined for it in the config file object.
* Updates swagger.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
