### PR TITLE
Bring in changes from Cosmos-SDK v0.46.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Improvements
 
-* Bring in Cosmos-SDK [v0.46.5](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.46.5) changes [#365](https://github.com/provenance-io/cosmos-sdk/pull/365).
+* Bring in Cosmos-SDK [v0.46.6](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.46.6) changes [#367](https://github.com/provenance-io/cosmos-sdk/pull/367).
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,18 @@ It also contains the Provenance Blockchain customizations that were part of [v0.
 
 # Cosmos-SDK releases
 
+## [v0.46.6](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.46.6) - 2022-11-18
+
+### Improvements
+
+* (config) [#13894](https://github.com/cosmos/cosmos-sdk/pull/13894) Support state streaming configuration in `app.toml` template and default configuration.
+
+## Bug Fixes
+
+* (x/gov) [#13918](https://github.com/cosmos/cosmos-sdk/pull/13918) Fix propagation of message errors when executing a proposal.
+
+---
+
 ## [v0.46.5](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.46.5) - 2022-11-17
 
 ### Features
@@ -210,6 +222,8 @@ It also contains the Provenance Blockchain customizations that were part of [v0.
 * (store) [#13803](https://github.com/cosmos/cosmos-sdk/pull/13803) Add an error log if IAVL set operation failed.
 * [#13861](https://github.com/cosmos/cosmos-sdk/pull/13861) Allow `_` characters in tx event queries, i.e. `GetTxsEvent`.
 
+---
+
 ## [v0.46.4](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.46.4) - 2022-11-01
 
 ### Features
@@ -232,6 +246,8 @@ It also contains the Provenance Blockchain customizations that were part of [v0.
 ### API Breaking Changes
 
 * (context) [#13063](https://github.com/cosmos/cosmos-sdk/pull/13063) Update `Context#CacheContext` to automatically emit all events on the parent context's `EventManager`.
+
+---
 
 ## [v0.46.3](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.46.3) - 2022-10-20
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,6 +12,33 @@
 
 ---
 
+## [v0.46.6](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.46.6) - 2022-11-18
+
+This release introduces small bug fixes and improvements.
+
+Please read the release notes of [v0.46.5](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.46.5) if you are upgrading from `<=0.46.4`.
+
+Please see the [CHANGELOG](https://github.com/cosmos/cosmos-sdk/blob/release/v0.46.x/CHANGELOG.md) for an exhaustive list of changes.
+
+Full Commit History: https://github.com/cosmos/cosmos-sdk/compare/v0.46.5...v0.46.6
+
+**NOTE**: The changes mentioned in `v0.46.3` are **still** required:
+
+```go
+# Chains must add the following to their go.mod for the application:
+replace github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
+```
+
+### Improvements
+
+* (config) [#13894](https://github.com/cosmos/cosmos-sdk/pull/13894) Support state streaming configuration in `app.toml` template and default configuration.
+
+## Bug Fixes
+
+* (x/gov) [#13918](https://github.com/cosmos/cosmos-sdk/pull/13918) Fix propagation of message errors when executing a proposal.
+
+---
+
 ## [v0.46.5](https://github.com/cosmos/cosmos-sdk/releases/tag/v0.46.5) - 2022-11-17
 
 This release introduces a number of serious bug fixes and improvements. Notably, an upgrade to Tendermint [v0.34.23](https://github.com/tendermint/tendermint/releases/tag/v0.34.23).

--- a/client/pruning/main.go
+++ b/client/pruning/main.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	pruningtypes "github.com/cosmos/cosmos-sdk/pruning/types"
@@ -40,7 +39,7 @@ func PruningCmd(appCreator servertypes.AppCreator) *cobra.Command {
 		`,
 		Example: "prune --home './' --app-db-backend 'goleveldb' --pruning 'custom' --pruning-keep-recent 100",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			vp := viper.New()
+			vp := server.GetServerContextFromCmd(cmd).Viper
 
 			// Bind flags to the Context's Viper so we can get pruning options.
 			if err := vp.BindPFlags(cmd.Flags()); err != nil {

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -33,6 +33,9 @@ const (
 	// DefaultGRPCMaxSendMsgSize defines the default gRPC max message size in
 	// bytes the server can send.
 	DefaultGRPCMaxSendMsgSize = math.MaxInt32
+
+	// FileStreamer defines the store streaming type for file streaming.
+	FileStreamer = "file"
 )
 
 // BaseConfig defines the server's basic configuration
@@ -196,6 +199,28 @@ type StateSyncConfig struct {
 	SnapshotKeepRecent uint32 `mapstructure:"snapshot-keep-recent"`
 }
 
+type (
+	// StoreConfig defines application configuration for state streaming and other
+	// storage related operations.
+	StoreConfig struct {
+		Streamers []string `mapstructure:"streamers"`
+	}
+
+	// StreamersConfig defines concrete state streaming configuration options. These
+	// fields are required to be set when state streaming is enabled via a non-empty
+	// list defined by 'StoreConfig.Streamers'.
+	StreamersConfig struct {
+		File FileStreamerConfig `mapstructure:"file"`
+	}
+
+	// FileStreamerConfig defines the file streaming configuration options.
+	FileStreamerConfig struct {
+		Keys     []string `mapstructure:"keys"`
+		WriteDir string   `mapstructure:"write_dir"`
+		Prefix   string   `mapstructure:"prefix"`
+	}
+)
+
 // Config defines the server's top level configuration
 type Config struct {
 	BaseConfig `mapstructure:",squash"`
@@ -207,6 +232,8 @@ type Config struct {
 	Rosetta   RosettaConfig    `mapstructure:"rosetta"`
 	GRPCWeb   GRPCWebConfig    `mapstructure:"grpc-web"`
 	StateSync StateSyncConfig  `mapstructure:"state-sync"`
+	Store     StoreConfig      `mapstructure:"store"`
+	Streamers StreamersConfig  `mapstructure:"streamers"`
 }
 
 // SetMinGasPrices sets the validator's minimum gas prices.
@@ -287,6 +314,14 @@ func DefaultConfig() *Config {
 		StateSync: StateSyncConfig{
 			SnapshotInterval:   0,
 			SnapshotKeepRecent: 2,
+		},
+		Store: StoreConfig{
+			Streamers: []string{},
+		},
+		Streamers: StreamersConfig{
+			File: FileStreamerConfig{
+				Keys: []string{"*"},
+			},
 		},
 	}
 }

--- a/server/config/config.go
+++ b/server/config/config.go
@@ -328,83 +328,11 @@ func DefaultConfig() *Config {
 
 // GetConfig returns a fully parsed Config object.
 func GetConfig(v *viper.Viper) (Config, error) {
-	globalLabelsRaw, ok := v.Get("telemetry.global-labels").([]interface{})
-	if !ok {
-		return Config{}, fmt.Errorf("failed to parse global-labels config")
+	conf := DefaultConfig()
+	if err := v.Unmarshal(conf); err != nil {
+		return Config{}, fmt.Errorf("error extracting app config: %w", err)
 	}
-
-	globalLabels := make([][]string, 0, len(globalLabelsRaw))
-	for idx, glr := range globalLabelsRaw {
-		labelsRaw, ok := glr.([]interface{})
-		if !ok {
-			return Config{}, fmt.Errorf("failed to parse global label number %d from config", idx)
-		}
-		if len(labelsRaw) == 2 {
-			globalLabels = append(globalLabels, []string{labelsRaw[0].(string), labelsRaw[1].(string)})
-		}
-	}
-
-	return Config{
-		BaseConfig: BaseConfig{
-			MinGasPrices:        v.GetString("minimum-gas-prices"),
-			InterBlockCache:     v.GetBool("inter-block-cache"),
-			Pruning:             v.GetString("pruning"),
-			PruningKeepRecent:   v.GetString("pruning-keep-recent"),
-			PruningInterval:     v.GetString("pruning-interval"),
-			HaltHeight:          v.GetUint64("halt-height"),
-			HaltTime:            v.GetUint64("halt-time"),
-			IndexEvents:         v.GetStringSlice("index-events"),
-			MinRetainBlocks:     v.GetUint64("min-retain-blocks"),
-			IAVLCacheSize:       v.GetUint64("iavl-cache-size"),
-			IAVLDisableFastNode: v.GetBool("iavl-disable-fastnode"),
-			AppDBBackend:        v.GetString("app-db-backend"),
-		},
-		Telemetry: telemetry.Config{
-			ServiceName:             v.GetString("telemetry.service-name"),
-			Enabled:                 v.GetBool("telemetry.enabled"),
-			EnableHostname:          v.GetBool("telemetry.enable-hostname"),
-			EnableHostnameLabel:     v.GetBool("telemetry.enable-hostname-label"),
-			EnableServiceLabel:      v.GetBool("telemetry.enable-service-label"),
-			PrometheusRetentionTime: v.GetInt64("telemetry.prometheus-retention-time"),
-			GlobalLabels:            globalLabels,
-		},
-		API: APIConfig{
-			Enable:             v.GetBool("api.enable"),
-			Swagger:            v.GetBool("api.swagger"),
-			Address:            v.GetString("api.address"),
-			MaxOpenConnections: v.GetUint("api.max-open-connections"),
-			RPCReadTimeout:     v.GetUint("api.rpc-read-timeout"),
-			RPCWriteTimeout:    v.GetUint("api.rpc-write-timeout"),
-			RPCMaxBodyBytes:    v.GetUint("api.rpc-max-body-bytes"),
-			EnableUnsafeCORS:   v.GetBool("api.enabled-unsafe-cors"),
-		},
-		Rosetta: RosettaConfig{
-			Enable:              v.GetBool("rosetta.enable"),
-			Address:             v.GetString("rosetta.address"),
-			Blockchain:          v.GetString("rosetta.blockchain"),
-			Network:             v.GetString("rosetta.network"),
-			Retries:             v.GetInt("rosetta.retries"),
-			Offline:             v.GetBool("rosetta.offline"),
-			EnableFeeSuggestion: v.GetBool("rosetta.enable-fee-suggestion"),
-			GasToSuggest:        v.GetInt("rosetta.gas-to-suggest"),
-			DenomToSuggest:      v.GetString("rosetta.denom-to-suggest"),
-		},
-		GRPC: GRPCConfig{
-			Enable:         v.GetBool("grpc.enable"),
-			Address:        v.GetString("grpc.address"),
-			MaxRecvMsgSize: v.GetInt("grpc.max-recv-msg-size"),
-			MaxSendMsgSize: v.GetInt("grpc.max-send-msg-size"),
-		},
-		GRPCWeb: GRPCWebConfig{
-			Enable:           v.GetBool("grpc-web.enable"),
-			Address:          v.GetString("grpc-web.address"),
-			EnableUnsafeCORS: v.GetBool("grpc-web.enable-unsafe-cors"),
-		},
-		StateSync: StateSyncConfig{
-			SnapshotInterval:   v.GetUint64("state-sync.snapshot-interval"),
-			SnapshotKeepRecent: v.GetUint32("state-sync.snapshot-keep-recent"),
-		},
-	}, nil
+	return *conf, nil
 }
 
 // ValidateBasic returns an error if min-gas-prices field is empty in BaseConfig. Otherwise, it returns nil.

--- a/server/config/toml.go
+++ b/server/config/toml.go
@@ -235,6 +235,19 @@ snapshot-interval = {{ .StateSync.SnapshotInterval }}
 
 # snapshot-keep-recent specifies the number of recent snapshots to keep and serve (0 to keep all).
 snapshot-keep-recent = {{ .StateSync.SnapshotKeepRecent }}
+
+###############################################################################
+###                         Store / State Streaming                         ###
+###############################################################################
+
+[store]
+streamers = [{{ range .Store.Streamers }}{{ printf "%q, " . }}{{end}}]
+
+[streamers]
+[streamers.file]
+keys = [{{ range .Streamers.File.Keys }}{{ printf "%q, " . }}{{end}}]
+write_dir = "{{ .Streamers.File.WriteDir }}"
+prefix = "{{ .Streamers.File.Prefix }}"
 `
 
 var configTemplate *template.Template

--- a/simapp/app.go
+++ b/simapp/app.go
@@ -2,6 +2,7 @@ package simapp
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -228,10 +229,10 @@ func NewSimApp(
 	// not include this key.
 	memKeys := sdk.NewMemoryStoreKeys(capabilitytypes.MemStoreKey, "testingkey")
 
-	// configure state listening capabilities using AppOptions
-	// we are doing nothing with the returned streamingServices and waitGroup in this case
+	// load state streaming if enabled
 	if _, _, err := streaming.LoadStreamingServices(bApp, appOpts, appCodec, keys); err != nil {
-		tmos.Exit(err.Error())
+		fmt.Printf("failed to load state streaming: %s", err)
+		os.Exit(1)
 	}
 
 	app := &SimApp{

--- a/store/streaming/README.md
+++ b/store/streaming/README.md
@@ -1,29 +1,38 @@
 # State Streaming Service
 
-This package contains the constructors for the `StreamingService`s used to write state changes out from individual KVStores to a
-file or stream, as described in [ADR-038](https://github.com/cosmos/cosmos-sdk/blob/main/docs/architecture/adr-038-state-listening.md) and defined in [types/streaming.go](https://github.com/cosmos/cosmos-sdk/blob/main/baseapp/streaming.go).
+This package contains the constructors for the `StreamingService`s used to write
+state changes out from individual KVStores to a file or stream, as described in
+[ADR-038](https://github.com/cosmos/cosmos-sdk/blob/main/docs/architecture/adr-038-state-listening.md)
+and defined in [types/streaming.go](https://github.com/cosmos/cosmos-sdk/blob/main/baseapp/streaming.go).
 The child directories contain the implementations for specific output destinations.
 
-Currently, a `StreamingService` implementation that writes state changes out to files is supported, in the future support for additional
-output destinations can be added.
+Currently, a `StreamingService` implementation that writes state changes out to
+files is supported, in the future support for additional output destinations can
+be added.
 
-The `StreamingService` is configured from within an App using the `AppOptions` loaded from the app.toml file:
+The `StreamingService` is configured from within an App using the `AppOptions`
+loaded from the `app.toml` file:
 
 ```toml
+# ...
+
 [store]
-    streamers = [ # if len(streamers) > 0 we are streaming
-        "file", # name of the streaming service, used by constructor
-    ]
+# streaming is enabled if one or more streamers are defined
+streamers = [
+    # name of the streaming service, used by constructor
+    "file"
+]
 
 [streamers]
-    [streamers.file]
-        keys = ["list", "of", "store", "keys", "we", "want", "to", "expose", "for", "this", "streaming", "service"]
-        write_dir = "path to the write directory"
-        prefix = "optional prefix to prepend to the generated file names"
+[streamers.file]
+    keys = ["list", "of", "store", "keys", "we", "want", "to", "expose", "for", "this", "streaming", "service"]
+    write_dir = "path to the write directory"
+    prefix = "optional prefix to prepend to the generated file names"
 ```
 
-`store.streamers` contains a list of the names of the `StreamingService` implementations to employ which are used by `ServiceTypeFromString`
-to return the `ServiceConstructor` for that particular implementation:
+The `store.streamers` field contains a list of the names of the `StreamingService`
+implementations to employ which are used by `ServiceTypeFromString` to return
+the `ServiceConstructor` for that particular implementation:
 
 ```go
 listeners := cast.ToStringSlice(appOpts.Get("store.streamers"))
@@ -35,18 +44,27 @@ for _, listenerName := range listeners {
 }
 ```
 
-`streamers` contains a mapping of the specific `StreamingService` implementation name to the configuration parameters for that specific service.
-`streamers.x.keys` contains the list of `StoreKey` names for the KVStores to expose using this service and is required by every type of `StreamingService`.
-In order to expose *all* KVStores, we can include `*` in this list. An empty list is equivalent to turning the service off.
+The `streamers` field contains a mapping of the specific `StreamingService`
+implementation name to the configuration parameters for that specific service.
+
+The `streamers.x.keys` field contains the list of `StoreKey` names for the
+KVStores to expose using this service and is required by every type of
+`StreamingService`. In order to expose *ALL* KVStores, we can include `*` in
+this list. An empty list is equivalent to turning the service off.
 
 Additional configuration parameters are optional and specific to the implementation.
-In the case of the file streaming service, `streamers.file.write_dir` contains the path to the
-directory to write the files to, and `streamers.file.prefix` contains an optional prefix to prepend to the output files to prevent potential collisions
-with other App `StreamingService` output files.
+In the case of the file streaming service, the `streamers.file.write_dir` field
+contains the path to the directory to write the files to, and `streamers.file.prefix`
+contains an optional prefix to prepend to the output files to prevent potential
+collisions with other App `StreamingService` output files.
 
-The `ServiceConstructor` accepts `AppOptions`, the store keys collected using `streamers.x.keys`, a `BinaryMarshaller` and
-returns a `StreamingService` implementation. The `AppOptions` are passed in to provide access to any implementation specific configuration options,
-e.g. in the case of the file streaming service the `streamers.file.write_dir` and `streamers.file.prefix`.
+The `ServiceConstructor` accepts `AppOptions`, the store keys collected using
+`streamers.x.keys`, a `BinaryMarshaller` and returns a `StreamingService
+implementation.
+
+The `AppOptions` are passed in to provide access to any implementation specific
+configuration options, e.g. in the case of the file streaming service the
+`streamers.file.write_dir` and `streamers.file.prefix`.
 
 ```go
 streamingService, err := constructor(appOpts, exposeStoreKeys, appCodec)
@@ -55,9 +73,12 @@ if err != nil {
 }
 ```
 
-The returned `StreamingService` is loaded into the BaseApp using the BaseApp's `SetStreamingService` method.
-The `Stream` method is called on the service to begin the streaming process. Depending on the implementation this process
-may be synchronous or asynchronous with the message processing of the state machine.
+The returned `StreamingService` is loaded into the BaseApp using the BaseApp's
+`SetStreamingService` method.
+
+The `Stream` method is called on the service to begin the streaming process.
+Depending on the implementation this process may be synchronous or asynchronous
+with the message processing of the state machine.
 
 ```go
 bApp.SetStreamingService(streamingService)

--- a/x/bank/keeper/migrations.go
+++ b/x/bank/keeper/migrations.go
@@ -34,3 +34,9 @@ func (m Migrator) Migrate3to4(ctx sdk.Context) error {
 	m.keeper.SetParams(ctx, banktypes.NewParams(oldParams.DefaultSendEnabled))
 	return nil
 }
+
+// Migrate3_V046_4_To_V046_5 fixes migrations from version 2 to for chains based on SDK 0.46.0 - v0.46.4 ONLY.
+// See v046.Migrate_V046_4_To_V046_5 for more details.
+func (m Migrator) Migrate3_V046_4_To_V046_5(ctx sdk.Context) error {
+	return v046.Migrate_V046_4_To_V046_5(ctx.KVStore(m.keeper.storeKey))
+}

--- a/x/gov/abci.go
+++ b/x/gov/abci.go
@@ -71,7 +71,9 @@ func EndBlocker(ctx sdk.Context, keeper keeper.Keeper) {
 			if err == nil {
 				for idx, msg = range messages {
 					handler := keeper.Router().Handler(msg)
-					res, err := handler(cacheCtx, msg)
+
+					var res *sdk.Result
+					res, err = handler(cacheCtx, msg)
 					if err != nil {
 						break
 					}

--- a/x/gov/common_test.go
+++ b/x/gov/common_test.go
@@ -78,8 +78,6 @@ func SortByteArrays(src [][]byte) [][]byte {
 	return sorted
 }
 
-const contextKeyBadProposal = "contextKeyBadProposal"
-
 var pubkeys = []cryptotypes.PubKey{
 	ed25519.GenPrivKey().PubKey(),
 	ed25519.GenPrivKey().PubKey(),

--- a/x/group/internal/math/dec.go
+++ b/x/group/internal/math/dec.go
@@ -46,10 +46,6 @@ func (x Dec) IsPositive() bool {
 	return !x.dec.Negative && !x.dec.IsZero()
 }
 
-func (x Dec) IsFinite() bool {
-	return x.dec.Form != apd.Finite
-}
-
 // NewDecFromString returns a new Dec from a string
 // It only support finite numbers, not NaN, +Inf, -Inf
 func NewDecFromString(s string) (Dec, error) {


### PR DESCRIPTION
## Description

This PR does the following:
1. Bring in the changes from Cosmos-SDK `v0.46.6`.
2. Update the `prune` command to use an existing viper instance instead of creating a new one. By creating a new one it was effectively ignoring the config files, most notably the `iavl-disable-fastnode` option.
3. Backport https://github.com/cosmos/cosmos-sdk/pull/13651 to fix the `GetConfig` function that wasn't reading two newly added config file sections: `Store` and `Streaming`.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
