### PR TITLE
Use permanent links in quarantine and sanction spec docs.

### DIFF
--- a/x/quarantine/spec/03_messages.md
+++ b/x/quarantine/spec/03_messages.md
@@ -9,7 +9,7 @@ order: 3
 An account can activate quarantine using a `MsgOptIn`.
 It contains only the address to quarantine.
 
-+++ https://github.com/provenance-io/cosmos-sdk/blob/prov/dwedul/1046-bank-quarantine/proto/cosmos/quarantine/v1beta1/tx.proto#L31-L36
++++ https://github.com/provenance-io/cosmos-sdk/blob/da2ea8a8139ae9e110de0776baffa1d0dd97db5e/proto/cosmos/quarantine/v1beta1/tx.proto#L33-L38
 
 It is expected to fail if the `to_address` is invalid.
 
@@ -18,7 +18,7 @@ It is expected to fail if the `to_address` is invalid.
 An account can deactivate quarantine using a `MsgOptOut`.
 It contains only the address to unquarantine.
 
-+++ https://github.com/provenance-io/cosmos-sdk/blob/prov/dwedul/1046-bank-quarantine/proto/cosmos/quarantine/v1beta1/tx.proto#L41-L46
++++ https://github.com/provenance-io/cosmos-sdk/blob/da2ea8a8139ae9e110de0776baffa1d0dd97db5e/proto/cosmos/quarantine/v1beta1/tx.proto#L43-L48
 
 It is expected to fail if the `to_address` is invalid.
 
@@ -28,7 +28,7 @@ Quarantined funds can be accepted by the intended receiver using a `MsgAccept`.
 It contains a `to_address` (receiver) and one or more `from_addresses` (senders).
 It also contains a flag to indicate whether auto-accept should be set up for all provided addresses.
 
-+++ https://github.com/provenance-io/cosmos-sdk/blob/prov/dwedul/1046-bank-quarantine/proto/cosmos/quarantine/v1beta1/tx.proto#L51-L67
++++ https://github.com/provenance-io/cosmos-sdk/blob/da2ea8a8139ae9e110de0776baffa1d0dd97db5e/proto/cosmos/quarantine/v1beta1/tx.proto#L53-L67
 
 Any quarantined funds for the `to_address` from any `from_address` are accepted (regardless of whether they've been previously declined).
 
@@ -42,13 +42,17 @@ It is expected to fail if:
 - No `from_addresses` are provided.
 - Any `from_addresses` are invalid.
 
+The response will contain a total of all funds released.
+
++++ https://github.com/provenance-io/cosmos-sdk/blob/da2ea8a8139ae9e110de0776baffa1d0dd97db5e/proto/cosmos/quarantine/v1beta1/tx.proto#L69-L74
+
 ## Msg/Decline
 
 Quarantined funds can be declined by the intended receiver using a `MsgDecline`.
 It contains a `to_address` (receiver) and one or more `from_addresses` (senders).
 It also contains a flag to indicate whether auto-decline should be set up for all provided addresses.
 
-+++ https://github.com/provenance-io/cosmos-sdk/blob/prov/dwedul/1046-bank-quarantine/proto/cosmos/quarantine/v1beta1/tx.proto#L72-L88
++++ https://github.com/provenance-io/cosmos-sdk/blob/da2ea8a8139ae9e110de0776baffa1d0dd97db5e/proto/cosmos/quarantine/v1beta1/tx.proto#L76-L90
 
 Any quarantined funds for the `to_address` from any `from_address` are declined.
 
@@ -67,7 +71,7 @@ It is expected to fail if:
 Auto-Responses can be defined either through the `permanent` flags with a `MsgAccept` or `MsgDecline`, or using a `MsgUpdateAutoResponses`.
 It contains a `to_address` and a list of `updates`. Each `AutoResponseUpdate` contains a `from_address` and the desired `response` for it.
 
-+++ https://github.com/provenance-io/cosmos-sdk/blob/prov/dwedul/1046-bank-quarantine/proto/cosmos/quarantine/v1beta1/tx.proto#L93-L102
++++ https://github.com/provenance-io/cosmos-sdk/blob/da2ea8a8139ae9e110de0776baffa1d0dd97db5e/proto/cosmos/quarantine/v1beta1/tx.proto#L95-L104
 
 Providing a `response` of `AUTO_RESPONSE_UNSPECIFIED` will cause the applicable entry to be deleted, allowing users to un-set previous auto-responses.
 

--- a/x/quarantine/spec/05_queries.md
+++ b/x/quarantine/spec/05_queries.md
@@ -11,11 +11,11 @@ The query takes in a `to_address` and outputs `true` if the address is quarantin
 
 Request:
 
-+++ https://github.com/provenance-io/cosmos-sdk/blob/prov/dwedul/1046-bank-quarantine/proto/cosmos/quarantine/v1beta1/query.proto#L46-50
++++ https://github.com/provenance-io/cosmos-sdk/blob/da2ea8a8139ae9e110de0776baffa1d0dd97db5e/proto/cosmos/quarantine/v1beta1/query.proto#L46-L50
 
 Response:
 
-+++ https://github.com/provenance-io/cosmos-sdk/blob/prov/dwedul/1046-bank-quarantine/proto/cosmos/quarantine/v1beta1/query.proto#L52-56
++++ https://github.com/provenance-io/cosmos-sdk/blob/da2ea8a8139ae9e110de0776baffa1d0dd97db5e/proto/cosmos/quarantine/v1beta1/query.proto#L52-L56
 
 It is expected to fail if the `to_address` is invalid.
 
@@ -26,15 +26,15 @@ This query takes in an optional `to_address` and optional `from_address` and out
 
 Request:
 
-+++ https://github.com/provenance-io/cosmos-sdk/blob/prov/dwedul/1046-bank-quarantine/proto/cosmos/quarantine/v1beta1/query.proto#L58-67
++++ https://github.com/provenance-io/cosmos-sdk/blob/da2ea8a8139ae9e110de0776baffa1d0dd97db5e/proto/cosmos/quarantine/v1beta1/query.proto#L58-L67
 
 Response:
 
-+++ https://github.com/provenance-io/cosmos-sdk/blob/prov/dwedul/1046-bank-quarantine/proto/cosmos/quarantine/v1beta1/query.proto#L69-76
++++ https://github.com/provenance-io/cosmos-sdk/blob/da2ea8a8139ae9e110de0776baffa1d0dd97db5e/proto/cosmos/quarantine/v1beta1/query.proto#L69-L76
 
 QuarantinedFunds:
 
-+++ https://github.com/provenance-io/cosmos-sdk/blob/prov/dwedul/1046-bank-quarantine/proto/cosmos/quarantine/v1beta1/quarantine.proto#L10-21
++++ https://github.com/provenance-io/cosmos-sdk/blob/da2ea8a8139ae9e110de0776baffa1d0dd97db5e/proto/cosmos/quarantine/v1beta1/quarantine.proto#L10-L21
 
 - If neither a `to_address` nor `from_address` are provided, all non-declined quarantined funds for any addresses will be returned.
 - If the request contains a `to_address` but no `from_address`, all non-declined quarantined funds for the `to_address` are returned.
@@ -54,15 +54,15 @@ This query takes in a `to_address` and optional `from_address` and outputs infor
 
 Request:
 
-+++ https://github.com/provenance-io/cosmos-sdk/blob/prov/dwedul/1046-bank-quarantine/proto/cosmos/quarantine/v1beta1/query.proto#L78-87
++++ https://github.com/provenance-io/cosmos-sdk/blob/da2ea8a8139ae9e110de0776baffa1d0dd97db5e/proto/cosmos/quarantine/v1beta1/query.proto#L78-L87
 
 Response:
 
-+++ https://github.com/provenance-io/cosmos-sdk/blob/prov/dwedul/1046-bank-quarantine/proto/cosmos/quarantine/v1beta1/query.proto#L89-96
++++ https://github.com/provenance-io/cosmos-sdk/blob/da2ea8a8139ae9e110de0776baffa1d0dd97db5e/proto/cosmos/quarantine/v1beta1/query.proto#L89-L96
 
 AutoResponseEntry:
 
-+++ https://github.com/provenance-io/cosmos-sdk/blob/prov/dwedul/1046-bank-quarantine/proto/cosmos/quarantine/v1beta1/quarantine.proto#L23-31
++++ https://github.com/provenance-io/cosmos-sdk/blob/da2ea8a8139ae9e110de0776baffa1d0dd97db5e/proto/cosmos/quarantine/v1beta1/quarantine.proto#L23-L31
 
 - If no `from_address` is provided, all auto-response entries for the provided `to_address` are returned. The results will not contain any entries for `AUTO_RESPONSE_UNSPECIFIED`.
 - If a `from_address` is provided, the auto-response setting that `to_address` has from `from_address` is returned. This result might be `AUTO_RESPONSE_UNSPECIFIED`.

--- a/x/sanction/spec/03_messages.md
+++ b/x/sanction/spec/03_messages.md
@@ -11,7 +11,7 @@ All Msg Service endpoints in the `x/sanction` module are for use with governance
 A user can request that accounts be sanctioned by submitting a governance proposal containing a `MsgSanction`.
 It contains the list of `addresses` of accounts to be sanctioned and the `authority` able to do it.
 
-+++ https://github.com/provenance-io/cosmos-sdk/blob/prov/dwedul/1046-sanction/proto/cosmos/sanction/v1beta1/tx.proto#L22-L32
++++ https://github.com/provenance-io/cosmos-sdk/blob/da2ea8a8139ae9e110de0776baffa1d0dd97db5e/proto/cosmos/sanction/v1beta1/tx.proto#L22-L32
 
 If the proposal ever has enough total deposit (defined in params), immediate temporary sanctions are issued for each address.
 Temporary sanctions expire at the completion of the governance proposal regardless of outcome.
@@ -30,7 +30,7 @@ It is expected to fail if:
 A user can request that accounts be unsanctioned by submitting a governance proposal containing a `MsgUnsanction`.
 It contains the list of `addresses` of accounts to be unsanctioned and the `authority` able to do it.
 
-+++ https://github.com/provenance-io/cosmos-sdk/blob/prov/dwedul/1046-sanction/proto/cosmos/sanction/v1beta1/tx.proto#L37-L47
++++ https://github.com/provenance-io/cosmos-sdk/blob/da2ea8a8139ae9e110de0776baffa1d0dd97db5e/proto/cosmos/sanction/v1beta1/tx.proto#L37-L47
 
 If the proposal ever has enough total deposit (defined in params), immediate temporary unsanctions are issued for each address.
 Temporary unsanctions expire at the completion of the governance proposal regardless of outcome.
@@ -48,7 +48,7 @@ It is expected to fail if:
 The sanction module params can be updated by submitting a governance proposal containing a `MsgUpdateParams`.
 It contains the desired new `params` and the `authority` able to update them.
 
-+++ https://github.com/provenance-io/cosmos-sdk/blob/prov/dwedul/1046-sanction/proto/cosmos/sanction/v1beta1/tx.proto#L52-L62
++++ https://github.com/provenance-io/cosmos-sdk/blob/da2ea8a8139ae9e110de0776baffa1d0dd97db5e/proto/cosmos/sanction/v1beta1/tx.proto#L52-L62
 
 If `params` is `null`, they will be deleted from state, reverting them to their code-defined defaults.
 If a field in `params` is `null` or empty, the record in state will reflect that.

--- a/x/sanction/spec/05_queries.md
+++ b/x/sanction/spec/05_queries.md
@@ -15,11 +15,11 @@ If it returns `false`, the account *is* allowed to move its funds (at least from
 
 Request:
 
-+++ https://github.com/provenance-io/cosmos-sdk/blob/prov/dwedul/1046-sanction/proto/cosmos/sanction/v1beta1/query.proto#L33-L36
++++ https://github.com/provenance-io/cosmos-sdk/blob/da2ea8a8139ae9e110de0776baffa1d0dd97db5e/proto/cosmos/sanction/v1beta1/query.proto#L34-L37
 
 Response:
 
-+++ https://github.com/provenance-io/cosmos-sdk/blob/prov/dwedul/1046-sanction/proto/cosmos/sanction/v1beta1/query.proto#L38-L42
++++ https://github.com/provenance-io/cosmos-sdk/blob/da2ea8a8139ae9e110de0776baffa1d0dd97db5e/proto/cosmos/sanction/v1beta1/query.proto#L39-L43
 
 It is expected to fail if the `address` is invalid.
 
@@ -30,11 +30,11 @@ It takes in `pagination` parameters and outputs a list of `addresses`.
 
 Request:
 
-+++ https://github.com/provenance-io/cosmos-sdk/blob/prov/dwedul/1046-sanction/proto/cosmos/sanction/v1beta1/query.proto#L44-L48
++++ https://github.com/provenance-io/cosmos-sdk/blob/da2ea8a8139ae9e110de0776baffa1d0dd97db5e/proto/cosmos/sanction/v1beta1/query.proto#L45-L49
 
 Response:
 
-+++ https://github.com/provenance-io/cosmos-sdk/blob/prov/dwedul/1046-sanction/proto/cosmos/sanction/v1beta1/query.proto#L50-L57
++++ https://github.com/provenance-io/cosmos-sdk/blob/da2ea8a8139ae9e110de0776baffa1d0dd97db5e/proto/cosmos/sanction/v1beta1/query.proto#L51-L58
 
 This query does not take into account temporary sanctions or temporary unsanctions. 
 Addresses that are temporarily sanctioned (but not permanently sanctioned) are **not** returned by this query.
@@ -51,19 +51,19 @@ It takes in `pagination` parameters and an optional `address`.
 
 Request:
 
-+++ https://github.com/provenance-io/cosmos-sdk/blob/prov/dwedul/1046-sanction/proto/cosmos/sanction/v1beta1/query.proto#L59-L66
++++ https://github.com/provenance-io/cosmos-sdk/blob/da2ea8a8139ae9e110de0776baffa1d0dd97db5e/proto/cosmos/sanction/v1beta1/query.proto#L60-L67
 
 Response:
 
-+++ https://github.com/provenance-io/cosmos-sdk/blob/prov/dwedul/1046-sanction/proto/cosmos/sanction/v1beta1/query.proto#L68-L74
++++ https://github.com/provenance-io/cosmos-sdk/blob/da2ea8a8139ae9e110de0776baffa1d0dd97db5e/proto/cosmos/sanction/v1beta1/query.proto#L69-L75
 
 TemporaryEntry:
 
-+++ https://github.com/provenance-io/cosmos-sdk/blob/prov/dwedul/1046-sanction/proto/cosmos/sanction/v1beta1/sanction.proto#L27-L34
++++ https://github.com/provenance-io/cosmos-sdk/blob/da2ea8a8139ae9e110de0776baffa1d0dd97db5e/proto/cosmos/sanction/v1beta1/sanction.proto#L27-L35
 
 TempStatus:
 
-+++ https://github.com/provenance-io/cosmos-sdk/blob/prov/dwedul/1046-sanction/proto/cosmos/sanction/v1beta1/sanction.proto#L36-L45
++++ https://github.com/provenance-io/cosmos-sdk/blob/da2ea8a8139ae9e110de0776baffa1d0dd97db5e/proto/cosmos/sanction/v1beta1/sanction.proto#L37-L47
 
 - If an `address` is provided, only temporary entries associated with that address are returned.
 - If an `address` is provided that does not have any temporary entries, a single `TemporaryEntry` with a `status` of `TEMP_STATUS_UNSPECIFIED` is returned.
@@ -83,11 +83,11 @@ It has no input and outputs the `params`.
 
 Request:
 
-+++ https://github.com/provenance-io/cosmos-sdk/blob/prov/dwedul/1046-sanction/proto/cosmos/sanction/v1beta1/query.proto#L76-L77
++++ https://github.com/provenance-io/cosmos-sdk/blob/da2ea8a8139ae9e110de0776baffa1d0dd97db5e/proto/cosmos/sanction/v1beta1/query.proto#L77-L78
 
 Response:
 
-+++ https://github.com/provenance-io/cosmos-sdk/blob/prov/dwedul/1046-sanction/proto/cosmos/sanction/v1beta1/query.proto#L79-L83
++++ https://github.com/provenance-io/cosmos-sdk/blob/da2ea8a8139ae9e110de0776baffa1d0dd97db5e/proto/cosmos/sanction/v1beta1/query.proto#L80-L84
 
 This query returns the values used for the params.
 That is, if there are params stored in state, they are returned;


### PR DESCRIPTION
## Description

closes: https://github.com/provenance-io/provenance/issues/1312

Updates the quarantine and sanction spec docs to use permanent code links.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
