### PR TITLE
Backport: Injectable locked coins(#577), prov version in status command (#578)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Features
 
+* [#578](https://github.com/provenance-io/cosmos-sdk/pull/578) Add `binary_version` to the `NodeInfo` object returned by status command.
 * [#577](https://github.com/provenance-io/cosmos-sdk/pull/577) Add an injectable `GetLockedCoinsFn` to the bank module.
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,9 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
-* nothing
+### Features
+
+* [#577](https://github.com/provenance-io/cosmos-sdk/pull/577) Add an injectable `GetLockedCoinsFn` to the bank module.
 
 ---
 

--- a/client/grpc/tmservice/service.go
+++ b/client/grpc/tmservice/service.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"
-	"github.com/cosmos/cosmos-sdk/client/rpc"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
 	qtypes "github.com/cosmos/cosmos-sdk/types/query"
@@ -80,7 +79,7 @@ func (s queryServer) GetLatestBlock(ctx context.Context, _ *GetLatestBlockReques
 
 // GetBlockByHeight implements ServiceServer.GetBlockByHeight
 func (s queryServer) GetBlockByHeight(ctx context.Context, req *GetBlockByHeightRequest) (*GetBlockByHeightResponse, error) {
-	chainHeight, err := rpc.GetChainHeight(s.clientCtx)
+	chainHeight, err := client.GetChainHeight(s.clientCtx)
 	if err != nil {
 		return nil, err
 	}
@@ -130,7 +129,7 @@ func (s queryServer) GetValidatorSetByHeight(ctx context.Context, req *GetValida
 		return nil, err
 	}
 
-	chainHeight, err := rpc.GetChainHeight(s.clientCtx)
+	chainHeight, err := client.GetChainHeight(s.clientCtx)
 	if err != nil {
 		return nil, status.Error(codes.Internal, "failed to parse chain height")
 	}
@@ -152,7 +151,7 @@ func (s queryServer) GetValidatorSetByHeight(ctx context.Context, req *GetValida
 }
 
 func validatorsOutput(ctx context.Context, cctx client.Context, height *int64, page, limit int) (*GetLatestValidatorSetResponse, error) {
-	vs, err := rpc.GetValidators(ctx, cctx, height, &page, &limit)
+	vs, err := client.GetValidators(ctx, cctx, height, &page, &limit)
 	if err != nil {
 		return nil, err
 	}

--- a/client/rpc.go
+++ b/client/rpc.go
@@ -1,0 +1,111 @@
+package client
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
+	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	tmtypes "github.com/tendermint/tendermint/types"
+)
+
+// get the current blockchain height
+func GetChainHeight(clientCtx Context) (int64, error) {
+	node, err := clientCtx.GetNode()
+	if err != nil {
+		return -1, err
+	}
+
+	status, err := node.Status(context.Background())
+	if err != nil {
+		return -1, err
+	}
+
+	height := status.SyncInfo.LatestBlockHeight
+	return height, nil
+}
+
+// Validator output
+type ValidatorOutput struct {
+	Address          sdk.ConsAddress    `json:"address"`
+	PubKey           cryptotypes.PubKey `json:"pub_key"`
+	ProposerPriority int64              `json:"proposer_priority"`
+	VotingPower      int64              `json:"voting_power"`
+}
+
+// Validators at a certain height output in bech32 format
+type ResultValidatorsOutput struct {
+	BlockHeight int64             `json:"block_height"`
+	Validators  []ValidatorOutput `json:"validators"`
+	Total       uint64            `json:"total"`
+}
+
+func (rvo ResultValidatorsOutput) String() string {
+	var b strings.Builder
+
+	b.WriteString(fmt.Sprintf("block height: %d\n", rvo.BlockHeight))
+	b.WriteString(fmt.Sprintf("total count: %d\n", rvo.Total))
+
+	for _, val := range rvo.Validators {
+		b.WriteString(
+			fmt.Sprintf(`
+  Address:          %s
+  Pubkey:           %s
+  ProposerPriority: %d
+  VotingPower:      %d
+		`,
+				val.Address, val.PubKey, val.ProposerPriority, val.VotingPower,
+			),
+		)
+	}
+
+	return b.String()
+}
+
+func validatorOutput(validator *tmtypes.Validator) (ValidatorOutput, error) {
+	pk, err := cryptocodec.FromTmPubKeyInterface(validator.PubKey)
+	if err != nil {
+		return ValidatorOutput{}, err
+	}
+
+	return ValidatorOutput{
+		Address:          sdk.ConsAddress(validator.Address),
+		PubKey:           pk,
+		ProposerPriority: validator.ProposerPriority,
+		VotingPower:      validator.VotingPower,
+	}, nil
+}
+
+// GetValidators from client
+func GetValidators(ctx context.Context, clientCtx Context, height *int64, page, limit *int) (ResultValidatorsOutput, error) {
+	// get the node
+	node, err := clientCtx.GetNode()
+	if err != nil {
+		return ResultValidatorsOutput{}, err
+	}
+
+	validatorsRes, err := node.Validators(ctx, height, page, limit)
+	if err != nil {
+		return ResultValidatorsOutput{}, err
+	}
+
+	total := validatorsRes.Total
+	if validatorsRes.Total < 0 {
+		total = 0
+	}
+	out := ResultValidatorsOutput{
+		BlockHeight: validatorsRes.BlockHeight,
+		Validators:  make([]ValidatorOutput, len(validatorsRes.Validators)),
+		Total:       uint64(total),
+	}
+	for i := 0; i < len(validatorsRes.Validators); i++ {
+		out.Validators[i], err = validatorOutput(validatorsRes.Validators[i])
+		if err != nil {
+			return out, err
+		}
+	}
+
+	return out, nil
+}

--- a/client/rpc/block.go
+++ b/client/rpc/block.go
@@ -69,19 +69,3 @@ func getBlock(clientCtx client.Context, height *int64) ([]byte, error) {
 
 	return legacy.Cdc.MarshalJSON(res)
 }
-
-// get the current blockchain height
-func GetChainHeight(clientCtx client.Context) (int64, error) {
-	node, err := clientCtx.GetNode()
-	if err != nil {
-		return -1, err
-	}
-
-	status, err := node.Status(context.Background())
-	if err != nil {
-		return -1, err
-	}
-
-	height := status.SyncInfo.LatestBlockHeight
-	return height, nil
-}

--- a/client/rpc/rpc_test.go
+++ b/client/rpc/rpc_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/rpc"
 	clitestutil "github.com/cosmos/cosmos-sdk/testutil/cli"
 	"github.com/cosmos/cosmos-sdk/testutil/network"
+	"github.com/cosmos/cosmos-sdk/version"
 )
 
 type IntegrationTestSuite struct {
@@ -41,6 +42,9 @@ func (s *IntegrationTestSuite) TestStatusCommand() {
 
 	// Make sure the output has the validator moniker.
 	s.Require().Contains(out.String(), fmt.Sprintf("\"moniker\":\"%s\"", val0.Moniker))
+
+	// Make sure the output has the binary name.
+	s.Require().Contains(out.String(), fmt.Sprintf("\"binary_version\":\"%s\"", version.NewInfo().Version))
 }
 
 func TestIntegrationTestSuite(t *testing.T) {

--- a/client/rpc/validators.go
+++ b/client/rpc/validators.go
@@ -1,20 +1,13 @@
 package rpc
 
 import (
-	"context"
-	"fmt"
 	"strconv"
-	"strings"
 
 	"github.com/spf13/cobra"
 	tmcli "github.com/tendermint/tendermint/libs/cli"
-	tmtypes "github.com/tendermint/tendermint/types"
 
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
-	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
-	cryptotypes "github.com/cosmos/cosmos-sdk/crypto/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
 )
 
@@ -49,7 +42,7 @@ func ValidatorCommand() *cobra.Command {
 			page, _ := cmd.Flags().GetInt(flags.FlagPage)
 			limit, _ := cmd.Flags().GetInt(flags.FlagLimit)
 
-			result, err := GetValidators(cmd.Context(), clientCtx, height, &page, &limit)
+			result, err := client.GetValidators(cmd.Context(), clientCtx, height, &page, &limit)
 			if err != nil {
 				return err
 			}
@@ -64,87 +57,4 @@ func ValidatorCommand() *cobra.Command {
 	cmd.Flags().Int(flags.FlagLimit, 100, "Query number of results returned per page")
 
 	return cmd
-}
-
-// Validator output
-type ValidatorOutput struct {
-	Address          sdk.ConsAddress    `json:"address"`
-	PubKey           cryptotypes.PubKey `json:"pub_key"`
-	ProposerPriority int64              `json:"proposer_priority"`
-	VotingPower      int64              `json:"voting_power"`
-}
-
-// Validators at a certain height output in bech32 format
-type ResultValidatorsOutput struct {
-	BlockHeight int64             `json:"block_height"`
-	Validators  []ValidatorOutput `json:"validators"`
-	Total       uint64            `json:"total"`
-}
-
-func (rvo ResultValidatorsOutput) String() string {
-	var b strings.Builder
-
-	b.WriteString(fmt.Sprintf("block height: %d\n", rvo.BlockHeight))
-	b.WriteString(fmt.Sprintf("total count: %d\n", rvo.Total))
-
-	for _, val := range rvo.Validators {
-		b.WriteString(
-			fmt.Sprintf(`
-  Address:          %s
-  Pubkey:           %s
-  ProposerPriority: %d
-  VotingPower:      %d
-		`,
-				val.Address, val.PubKey, val.ProposerPriority, val.VotingPower,
-			),
-		)
-	}
-
-	return b.String()
-}
-
-func validatorOutput(validator *tmtypes.Validator) (ValidatorOutput, error) {
-	pk, err := cryptocodec.FromTmPubKeyInterface(validator.PubKey)
-	if err != nil {
-		return ValidatorOutput{}, err
-	}
-
-	return ValidatorOutput{
-		Address:          sdk.ConsAddress(validator.Address),
-		PubKey:           pk,
-		ProposerPriority: validator.ProposerPriority,
-		VotingPower:      validator.VotingPower,
-	}, nil
-}
-
-// GetValidators from client
-func GetValidators(ctx context.Context, clientCtx client.Context, height *int64, page, limit *int) (ResultValidatorsOutput, error) {
-	// get the node
-	node, err := clientCtx.GetNode()
-	if err != nil {
-		return ResultValidatorsOutput{}, err
-	}
-
-	validatorsRes, err := node.Validators(ctx, height, page, limit)
-	if err != nil {
-		return ResultValidatorsOutput{}, err
-	}
-
-	total := validatorsRes.Total
-	if validatorsRes.Total < 0 {
-		total = 0
-	}
-	out := ResultValidatorsOutput{
-		BlockHeight: validatorsRes.BlockHeight,
-		Validators:  make([]ValidatorOutput, len(validatorsRes.Validators)),
-		Total:       uint64(total),
-	}
-	for i := 0; i < len(validatorsRes.Validators); i++ {
-		out.Validators[i], err = validatorOutput(validatorsRes.Validators[i])
-		if err != nil {
-			return out, err
-		}
-	}
-
-	return out, nil
 }

--- a/simapp/sim_test.go
+++ b/simapp/sim_test.go
@@ -254,15 +254,15 @@ func TestAppSimulationAfterImport(t *testing.T) {
 		PrintStats(db)
 	}
 
-	if stopEarly {
-		fmt.Println("can't export or import a zero-validator genesis, exiting test...")
-		return
-	}
-
 	fmt.Printf("exporting genesis...\n")
 
 	exported, err := app.ExportAppStateAndValidators(true, []string{})
 	require.NoError(t, err)
+
+	if stopEarly || len(exported.Validators) == 0 {
+		fmt.Println("can't import a zero-validator genesis, exiting test...")
+		return
+	}
 
 	fmt.Printf("importing genesis...\n")
 

--- a/x/bank/keeper/export_test.go
+++ b/x/bank/keeper/export_test.go
@@ -5,10 +5,25 @@ import "github.com/cosmos/cosmos-sdk/x/bank/types"
 // This file exists in the keeper package to expose some private things
 // for the purpose of testing in the keeper_test package.
 
+// SetSendRestriction is a TEST ONLY method for overwriting the SendRestrictionFn.
 func (k BaseSendKeeper) SetSendRestriction(restriction types.SendRestrictionFn) {
 	k.sendRestriction.fn = restriction
 }
 
+// GetSendRestrictionFn is a TEST ONLY exposure of the currently defined SendRestrictionFn.
 func (k BaseSendKeeper) GetSendRestrictionFn() types.SendRestrictionFn {
 	return k.sendRestriction.fn
 }
+
+// SetLockedCoinsGetter is a TEST ONLY method for overwriting the GetLockedCoinsFn.
+func (k BaseSendKeeper) SetLockedCoinsGetter(getter types.GetLockedCoinsFn) {
+	k.lockedCoinsGetter.fn = getter
+}
+
+// GetLockedCoinsGetter is a TEST ONLY exposure of the currently defined GetLockedCoinsFn.
+func (k BaseViewKeeper) GetLockedCoinsGetter() types.GetLockedCoinsFn {
+	return k.lockedCoinsGetter.fn
+}
+
+// GetLockedCoinsFnWrapper is a TEST ONLY exposure of the getLockedCoinsFnWrapper function.
+var GetLockedCoinsFnWrapper = getLockedCoinsFnWrapper

--- a/x/bank/keeper/keeper.go
+++ b/x/bank/keeper/keeper.go
@@ -161,6 +161,10 @@ func (k BaseKeeper) DelegateCoins(ctx sdk.Context, delegatorAddr, moduleAccAddr 
 		}
 	}
 
+	if _, err := k.sendRestriction.apply(ctx, delegatorAddr, moduleAccAddr, amt); err != nil {
+		return err
+	}
+
 	if err := k.trackDelegation(ctx, delegatorAddr, balances, amt); err != nil {
 		return sdkerrors.Wrap(err, "failed to track delegation")
 	}

--- a/x/bank/keeper/keeper_test.go
+++ b/x/bank/keeper/keeper_test.go
@@ -531,14 +531,7 @@ func (suite *IntegrationTestSuite) TestInputOutputCoinsWithRestrictions() {
 			inputCoins:  sdk.NewCoins(newFooCoin(10)),
 			outputs:     []types.Output{{Address: toAddr1.String(), Coins: sdk.NewCoins(newFooCoin(10))}},
 			outputAddrs: []sdk.AccAddress{toAddr1},
-			expArgs: []*restrictionArgs{
-				{
-					ctx:      suite.ctx,
-					fromAddr: fromAddr,
-					toAddr:   toAddr1,
-					amt:      sdk.NewCoins(newFooCoin(10)),
-				},
-			},
+			expArgs:     []*restrictionArgs{{fromAddr: fromAddr, toAddr: toAddr1, amt: sdk.NewCoins(newFooCoin(10))}},
 			expBals: expBals{
 				from: sdk.NewCoins(newFooCoin(985), newBarCoin(500)),
 				to1:  sdk.NewCoins(newFooCoin(15)),
@@ -551,14 +544,7 @@ func (suite *IntegrationTestSuite) TestInputOutputCoinsWithRestrictions() {
 			inputCoins:  sdk.NewCoins(newFooCoin(26)),
 			outputs:     []types.Output{{Address: toAddr1.String(), Coins: sdk.NewCoins(newFooCoin(26))}},
 			outputAddrs: []sdk.AccAddress{toAddr2},
-			expArgs: []*restrictionArgs{
-				{
-					ctx:      suite.ctx,
-					fromAddr: fromAddr,
-					toAddr:   toAddr1,
-					amt:      sdk.NewCoins(newFooCoin(26)),
-				},
-			},
+			expArgs:     []*restrictionArgs{{fromAddr: fromAddr, toAddr: toAddr1, amt: sdk.NewCoins(newFooCoin(26))}},
 			expBals: expBals{
 				from: sdk.NewCoins(newFooCoin(959), newBarCoin(500)),
 				to1:  sdk.NewCoins(newFooCoin(15)),
@@ -571,17 +557,10 @@ func (suite *IntegrationTestSuite) TestInputOutputCoinsWithRestrictions() {
 			inputCoins:  sdk.NewCoins(newBarCoin(88)),
 			outputs:     []types.Output{{Address: toAddr1.String(), Coins: sdk.NewCoins(newBarCoin(88))}},
 			outputAddrs: []sdk.AccAddress{},
-			expArgs: []*restrictionArgs{
-				{
-					ctx:      suite.ctx,
-					fromAddr: fromAddr,
-					toAddr:   toAddr1,
-					amt:      sdk.NewCoins(newBarCoin(88)),
-				},
-			},
-			expErr: "restriction test error",
+			expArgs:     []*restrictionArgs{{fromAddr: fromAddr, toAddr: toAddr1, amt: sdk.NewCoins(newBarCoin(88))}},
+			expErr:      "restriction test error",
 			expBals: expBals{
-				from: sdk.NewCoins(newFooCoin(959), newBarCoin(412)),
+				from: sdk.NewCoins(newFooCoin(959), newBarCoin(500)),
 				to1:  sdk.NewCoins(newFooCoin(15)),
 				to2:  sdk.NewCoins(newFooCoin(26)),
 			},
@@ -596,21 +575,11 @@ func (suite *IntegrationTestSuite) TestInputOutputCoinsWithRestrictions() {
 			},
 			outputAddrs: []sdk.AccAddress{toAddr1, toAddr2},
 			expArgs: []*restrictionArgs{
-				{
-					ctx:      suite.ctx,
-					fromAddr: fromAddr,
-					toAddr:   toAddr1,
-					amt:      sdk.NewCoins(newFooCoin(11)),
-				},
-				{
-					ctx:      suite.ctx,
-					fromAddr: fromAddr,
-					toAddr:   toAddr2,
-					amt:      sdk.NewCoins(newBarCoin(12)),
-				},
+				{fromAddr: fromAddr, toAddr: toAddr1, amt: sdk.NewCoins(newFooCoin(11))},
+				{fromAddr: fromAddr, toAddr: toAddr2, amt: sdk.NewCoins(newBarCoin(12))},
 			},
 			expBals: expBals{
-				from: sdk.NewCoins(newFooCoin(948), newBarCoin(400)),
+				from: sdk.NewCoins(newFooCoin(948), newBarCoin(488)),
 				to1:  sdk.NewCoins(newFooCoin(26)),
 				to2:  sdk.NewCoins(newFooCoin(26), newBarCoin(12)),
 			},
@@ -625,23 +594,13 @@ func (suite *IntegrationTestSuite) TestInputOutputCoinsWithRestrictions() {
 			},
 			outputAddrs: []sdk.AccAddress{toAddr1},
 			expArgs: []*restrictionArgs{
-				{
-					ctx:      suite.ctx,
-					fromAddr: fromAddr,
-					toAddr:   toAddr1,
-					amt:      sdk.NewCoins(newFooCoin(12)),
-				},
-				{
-					ctx:      suite.ctx,
-					fromAddr: fromAddr,
-					toAddr:   toAddr2,
-					amt:      sdk.NewCoins(newFooCoin(32)),
-				},
+				{fromAddr: fromAddr, toAddr: toAddr1, amt: sdk.NewCoins(newFooCoin(12))},
+				{fromAddr: fromAddr, toAddr: toAddr2, amt: sdk.NewCoins(newFooCoin(32))},
 			},
 			expErr: "second restriction error",
 			expBals: expBals{
-				from: sdk.NewCoins(newFooCoin(904), newBarCoin(400)),
-				to1:  sdk.NewCoins(newFooCoin(38)),
+				from: sdk.NewCoins(newFooCoin(948), newBarCoin(488)),
+				to1:  sdk.NewCoins(newFooCoin(26)),
 				to2:  sdk.NewCoins(newFooCoin(26), newBarCoin(12)),
 			},
 		},
@@ -655,22 +614,12 @@ func (suite *IntegrationTestSuite) TestInputOutputCoinsWithRestrictions() {
 			},
 			outputAddrs: []sdk.AccAddress{toAddr1, toAddr2},
 			expArgs: []*restrictionArgs{
-				{
-					ctx:      suite.ctx,
-					fromAddr: fromAddr,
-					toAddr:   toAddr1,
-					amt:      sdk.NewCoins(newBarCoin(10)),
-				},
-				{
-					ctx:      suite.ctx,
-					fromAddr: fromAddr,
-					toAddr:   toAddr2,
-					amt:      sdk.NewCoins(newBarCoin(25)),
-				},
+				{fromAddr: fromAddr, toAddr: toAddr1, amt: sdk.NewCoins(newBarCoin(10))},
+				{fromAddr: fromAddr, toAddr: toAddr2, amt: sdk.NewCoins(newBarCoin(25))},
 			},
 			expBals: expBals{
-				from: sdk.NewCoins(newFooCoin(904), newBarCoin(365)),
-				to1:  sdk.NewCoins(newFooCoin(38), newBarCoin(25)),
+				from: sdk.NewCoins(newFooCoin(948), newBarCoin(453)),
+				to1:  sdk.NewCoins(newFooCoin(26), newBarCoin(25)),
 				to2:  sdk.NewCoins(newFooCoin(26), newBarCoin(22)),
 			},
 		},
@@ -685,7 +634,7 @@ func (suite *IntegrationTestSuite) TestInputOutputCoinsWithRestrictions() {
 			actualRestrictionArgs = nil
 			baseKeeper.SetSendRestriction(tc.fn)
 
-			ctx := suite.ctx
+			ctx, writeCache := suite.ctx.CacheContext()
 			input := types.Input{
 				Address: fromAddr.String(),
 				Coins:   tc.inputCoins,
@@ -696,6 +645,9 @@ func (suite *IntegrationTestSuite) TestInputOutputCoinsWithRestrictions() {
 				err = baseKeeper.InputOutputCoins(ctx, input, tc.outputs)
 			}
 			suite.Require().NotPanics(testFunc, "InputOutputCoins")
+			if err == nil {
+				writeCache()
+			}
 			if len(tc.expErr) > 0 {
 				suite.Assert().EqualError(err, tc.expErr, "InputOutputCoins error")
 			} else {
@@ -703,7 +655,7 @@ func (suite *IntegrationTestSuite) TestInputOutputCoinsWithRestrictions() {
 			}
 			if len(tc.expArgs) > 0 {
 				for i, expArgs := range tc.expArgs {
-					suite.Assert().Equal(expArgs.ctx, actualRestrictionArgs[i].ctx, "[%d] ctx provided to restriction", i)
+					suite.Assert().Equal(ctx, actualRestrictionArgs[i].ctx, "[%d] ctx provided to restriction", i)
 					suite.Assert().Equal(expArgs.fromAddr, actualRestrictionArgs[i].fromAddr, "[%d] fromAddr provided to restriction", i)
 					suite.Assert().Equal(expArgs.toAddr, actualRestrictionArgs[i].toAddr, "[%d] toAddr provided to restriction", i)
 					suite.Assert().Equal(expArgs.amt.String(), actualRestrictionArgs[i].amt.String(), "[%d] amt provided to restriction", i)
@@ -711,11 +663,11 @@ func (suite *IntegrationTestSuite) TestInputOutputCoinsWithRestrictions() {
 			} else {
 				suite.Assert().Nil(actualRestrictionArgs, "args provided to a restriction")
 			}
-			fromBal := baseKeeper.GetAllBalances(ctx, fromAddr)
+			fromBal := baseKeeper.GetAllBalances(suite.ctx, fromAddr)
 			suite.Assert().Equal(tc.expBals.from.String(), fromBal.String(), "fromAddr balance")
-			to1Bal := baseKeeper.GetAllBalances(ctx, toAddr1)
+			to1Bal := baseKeeper.GetAllBalances(suite.ctx, toAddr1)
 			suite.Assert().Equal(tc.expBals.to1.String(), to1Bal.String(), "toAddr1 balance")
-			to2Bal := baseKeeper.GetAllBalances(ctx, toAddr2)
+			to2Bal := baseKeeper.GetAllBalances(suite.ctx, toAddr2)
 			suite.Assert().Equal(tc.expBals.to2.String(), to2Bal.String(), "toAddr2 balance")
 		})
 	}
@@ -805,9 +757,9 @@ func (suite *IntegrationTestSuite) TestSendCoinsWithRestrictions() {
 		to2  sdk.Coins
 	}
 
-	addr1 := sdk.AccAddress("addr1_iocoinsr______")
-	addr2 := sdk.AccAddress("addr2_iocoinsr______")
-	addr3 := sdk.AccAddress("addr3_iocoinsr______")
+	addr1 := sdk.AccAddress("addr1_sendcoinsr____")
+	addr2 := sdk.AccAddress("addr2_sendcoinsr____")
+	addr3 := sdk.AccAddress("addr3_sendcoinsr____")
 
 	app, setupCtx := suite.app, suite.ctx
 	balances := sdk.NewCoins(newFooCoin(1000), newBarCoin(500))
@@ -852,12 +804,7 @@ func (suite *IntegrationTestSuite) TestSendCoinsWithRestrictions() {
 			toAddr:    toAddr1,
 			finalAddr: toAddr1,
 			amt:       sdk.NewCoins(newFooCoin(10)),
-			expArgs: &restrictionArgs{
-				ctx:      suite.ctx,
-				fromAddr: fromAddr,
-				toAddr:   toAddr1,
-				amt:      sdk.NewCoins(newFooCoin(10)),
-			},
+			expArgs:   &restrictionArgs{fromAddr: fromAddr, toAddr: toAddr1, amt: sdk.NewCoins(newFooCoin(10))},
 			expBals: expBals{
 				from: sdk.NewCoins(newFooCoin(985), newBarCoin(500)),
 				to1:  sdk.NewCoins(newFooCoin(15)),
@@ -870,12 +817,7 @@ func (suite *IntegrationTestSuite) TestSendCoinsWithRestrictions() {
 			toAddr:    toAddr1,
 			finalAddr: toAddr2,
 			amt:       sdk.NewCoins(newBarCoin(27)),
-			expArgs: &restrictionArgs{
-				ctx:      suite.ctx,
-				fromAddr: fromAddr,
-				toAddr:   toAddr1,
-				amt:      sdk.NewCoins(newBarCoin(27)),
-			},
+			expArgs:   &restrictionArgs{fromAddr: fromAddr, toAddr: toAddr1, amt: sdk.NewCoins(newBarCoin(27))},
 			expBals: expBals{
 				from: sdk.NewCoins(newFooCoin(985), newBarCoin(473)),
 				to1:  sdk.NewCoins(newFooCoin(15)),
@@ -888,13 +830,8 @@ func (suite *IntegrationTestSuite) TestSendCoinsWithRestrictions() {
 			toAddr:    toAddr1,
 			finalAddr: toAddr1,
 			amt:       sdk.NewCoins(newFooCoin(100), newBarCoin(200)),
-			expArgs: &restrictionArgs{
-				ctx:      suite.ctx,
-				fromAddr: fromAddr,
-				toAddr:   toAddr1,
-				amt:      sdk.NewCoins(newFooCoin(100), newBarCoin(200)),
-			},
-			expErr: "test restriction error",
+			expArgs:   &restrictionArgs{fromAddr: fromAddr, toAddr: toAddr1, amt: sdk.NewCoins(newFooCoin(100), newBarCoin(200))},
+			expErr:    "test restriction error",
 			expBals: expBals{
 				from: sdk.NewCoins(newFooCoin(985), newBarCoin(473)),
 				to1:  sdk.NewCoins(newFooCoin(15)),
@@ -911,31 +848,34 @@ func (suite *IntegrationTestSuite) TestSendCoinsWithRestrictions() {
 			defer baseKeeper.SetSendRestriction(existingSendRestrictionFn)
 			actualRestrictionArgs = nil
 			baseKeeper.SetSendRestriction(tc.fn)
-			ctx := suite.ctx
+			ctx, writeCache := suite.ctx.CacheContext()
 
 			var err error
 			testFunc := func() {
 				err = baseKeeper.SendCoins(ctx, fromAddr, tc.toAddr, tc.amt)
 			}
 			suite.Require().NotPanics(testFunc, "SendCoins")
+			if err == nil {
+				writeCache()
+			}
 			if len(tc.expErr) > 0 {
 				suite.Assert().EqualError(err, tc.expErr, "SendCoins error")
 			} else {
 				suite.Assert().NoError(err, "SendCoins error")
 			}
 			if tc.expArgs != nil {
-				suite.Assert().Equal(tc.expArgs.ctx, actualRestrictionArgs.ctx, "ctx provided to restriction")
+				suite.Assert().Equal(ctx, actualRestrictionArgs.ctx, "ctx provided to restriction")
 				suite.Assert().Equal(tc.expArgs.fromAddr, actualRestrictionArgs.fromAddr, "fromAddr provided to restriction")
 				suite.Assert().Equal(tc.expArgs.toAddr, actualRestrictionArgs.toAddr, "toAddr provided to restriction")
 				suite.Assert().Equal(tc.expArgs.amt.String(), actualRestrictionArgs.amt.String(), "amt provided to restriction")
 			} else {
 				suite.Assert().Nil(actualRestrictionArgs, "args provided to a restriction")
 			}
-			fromBal := baseKeeper.GetAllBalances(ctx, fromAddr)
+			fromBal := baseKeeper.GetAllBalances(suite.ctx, fromAddr)
 			suite.Assert().Equal(tc.expBals.from.String(), fromBal.String(), "fromAddr balance")
-			to1Bal := baseKeeper.GetAllBalances(ctx, toAddr1)
+			to1Bal := baseKeeper.GetAllBalances(suite.ctx, toAddr1)
 			suite.Assert().Equal(tc.expBals.to1.String(), to1Bal.String(), "toAddr1 balance")
-			to2Bal := baseKeeper.GetAllBalances(ctx, toAddr2)
+			to2Bal := baseKeeper.GetAllBalances(suite.ctx, toAddr2)
 			suite.Assert().Equal(tc.expBals.to2.String(), to2Bal.String(), "toAddr2 balance")
 		})
 	}
@@ -1096,56 +1036,142 @@ func (suite *IntegrationTestSuite) TestMsgMultiSendEvents() {
 		{Address: addr4.String(), Coins: newCoins2},
 	}
 
-	ctx = ctx.WithEventManager(sdk.NewEventManager())
-	suite.Require().Error(app.BankKeeper.InputOutputCoins(ctx, input, outputs))
+	abciEventsStrings := func(events []abci.Event) []string {
+		rv := []string(nil)
+		for i, event := range events {
+			if len(event.Type) == 0 {
+				rv = append(rv, fmt.Sprintf("[%d]{ignored}", i))
+			}
+			for j, attr := range event.Attributes {
+				rv = append(rv, fmt.Sprintf("[%d]%s[%d]: %q = %q", i, event.Type, j, string(attr.Key), string(attr.Value)))
+			}
+		}
+		return rv
+	}
 
-	events := ctx.EventManager().ABCIEvents()
-	suite.Require().Equal(0, len(events))
+	abciEvent := func(typeName string, attrs ...abci.EventAttribute) abci.Event {
+		return abci.Event{
+			Type:       typeName,
+			Attributes: attrs,
+		}
+	}
+	abciAttr := func(key, value string) abci.EventAttribute {
+		return abci.EventAttribute{
+			Key:   []byte(key),
+			Value: []byte(value),
+		}
+	}
+
+	coinReceived := types.EventTypeCoinReceived
+	transfer := types.EventTypeTransfer
+	receiver := types.AttributeKeyReceiver
+	recipient := types.AttributeKeyRecipient
+	amount := sdk.AttributeKeyAmount
+
+	expFailEvents := []abci.Event{}
+
+	emF := sdk.NewEventManager()
+	ctx = ctx.WithEventManager(emF)
+	suite.Require().Error(app.BankKeeper.InputOutputCoins(ctx, input, outputs))
+	events := emF.ABCIEvents()
+	if !suite.Assert().Equal(expFailEvents, events, "events after InputOutputCoins failure") {
+		suite.T().Logf("Expected Events:\n%s", strings.Join(abciEventsStrings(expFailEvents), "\n"))
+		suite.T().Logf("Actual Events:\n%s", strings.Join(abciEventsStrings(events), "\n"))
+	}
 
 	// Set addr's coins
 	suite.Require().NoError(testutil.FundAccount(app.BankKeeper, ctx, addr, coins))
 	newCoins = sdk.NewCoins(sdk.NewInt64Coin(fooDenom, 50))
 
-	ctx = ctx.WithEventManager(sdk.NewEventManager())
+	coinSpent := types.EventTypeCoinSpent
+	spender := types.AttributeKeySpender
+	message := sdk.EventTypeMessage
+	sender := types.AttributeKeySender
+
+	expPassEvents := []abci.Event{
+		abciEvent(coinSpent, abciAttr(spender, addr.String()), abciAttr(amount, coins.String())),
+		abciEvent(message, abciAttr(sender, addr.String())),
+		abciEvent(coinReceived, abciAttr(receiver, addr3.String()), abciAttr(amount, newCoins.String())),
+		abciEvent(transfer, abciAttr(recipient, addr3.String()), abciAttr(amount, newCoins.String())),
+		abciEvent(coinReceived, abciAttr(receiver, addr4.String()), abciAttr(amount, newCoins2.String())),
+		abciEvent(transfer, abciAttr(recipient, addr4.String()), abciAttr(amount, newCoins2.String())),
+	}
+
+	emS := sdk.NewEventManager()
+	ctx = ctx.WithEventManager(emS)
 	suite.Require().NoError(app.BankKeeper.InputOutputCoins(ctx, input, outputs))
+	events = emS.ABCIEvents()
+	if !suite.Assert().Equal(expPassEvents, events, "events after InputOutputCoins success") {
+		suite.T().Logf("Expected Events:\n%s", strings.Join(abciEventsStrings(expPassEvents), "\n"))
+		suite.T().Logf("Actual Events:\n%s", strings.Join(abciEventsStrings(events), "\n"))
+	}
+}
 
-	events = ctx.EventManager().ABCIEvents()
-	suite.Require().Len(events, 6)
+func (suite *IntegrationTestSuite) TestGetLockedCoinsFnWrapper() {
+	// Not using the coin/coins constructors since we want to be able to create bad ones.
+	c := func(amt int64, denom string) sdk.Coin {
+		return sdk.Coin{Amount: sdk.NewInt(amt), Denom: denom}
+	}
+	cz := func(coins ...sdk.Coin) sdk.Coins {
+		return coins
+	}
 
-	event2 := sdk.Event{
-		Type:       sdk.EventTypeMessage,
-		Attributes: []abci.EventAttribute{},
+	tests := []struct {
+		name string
+		rv   sdk.Coins
+		exp  sdk.Coins
+	}{
+		{
+			name: "one positive coin",
+			rv:   cz(c(1, "okcoin")),
+			exp:  cz(c(1, "okcoin")),
+		},
+		{
+			name: "one zero coin",
+			rv:   cz(c(0, "zerocoin")),
+			exp:  sdk.Coins{},
+		},
+		{
+			name: "one negative coin",
+			rv:   cz(c(-1, "negcoin")),
+			exp:  sdk.Coins{},
+		},
+		{
+			name: "one positive one zero and one negative",
+			rv:   cz(c(1, "okcoin"), c(0, "zerocoin"), c(-1, "negcoin")),
+			exp:  cz(c(1, "okcoin")),
+		},
+		{
+			name: "two of same denom both positive",
+			rv:   cz(c(1, "twocoin"), c(4, "twocoin")),
+			exp:  cz(c(5, "twocoin")),
+		},
+		{
+			name: "two of same denom but one is negative",
+			rv:   cz(c(1, "badcoin"), c(-1, "badcoin")),
+			exp:  cz(c(1, "badcoin")),
+		},
+		{
+			name: "a bit of everything",
+			rv:   cz(c(-1, "weird"), c(1, "weird"), c(0, "weird"), c(8, "okay"), c(4, "weird"), c(0, "zero")),
+			exp:  cz(c(8, "okay"), c(5, "weird")),
+		},
 	}
-	event2.Attributes = append(
-		event2.Attributes,
-		abci.EventAttribute{Key: []byte(types.AttributeKeySender), Value: []byte(addr.String())},
-	)
-	event3 := sdk.Event{
-		Type:       types.EventTypeTransfer,
-		Attributes: []abci.EventAttribute{},
+
+	for _, tc := range tests {
+		suite.Run(tc.name, func() {
+			testAddr := sdk.AccAddress("testAddr____________")
+			var addr sdk.AccAddress
+			getter := func(_ sdk.Context, getterAddr sdk.AccAddress) sdk.Coins {
+				addr = getterAddr
+				return tc.rv
+			}
+			wrapped := keeper.GetLockedCoinsFnWrapper(getter)
+			coins := wrapped(sdk.Context{}, testAddr)
+			suite.Assert().Equal(tc.exp.String(), coins.String(), "wrapped result")
+			suite.Assert().Equal(testAddr, addr, "address provided to wrapped getter")
+		})
 	}
-	event3.Attributes = append(
-		event3.Attributes,
-		abci.EventAttribute{Key: []byte(types.AttributeKeyRecipient), Value: []byte(addr3.String())},
-	)
-	event3.Attributes = append(
-		event3.Attributes,
-		abci.EventAttribute{Key: []byte(sdk.AttributeKeyAmount), Value: []byte(newCoins.String())})
-	event4 := sdk.Event{
-		Type:       types.EventTypeTransfer,
-		Attributes: []abci.EventAttribute{},
-	}
-	event4.Attributes = append(
-		event4.Attributes,
-		abci.EventAttribute{Key: []byte(types.AttributeKeyRecipient), Value: []byte(addr4.String())},
-	)
-	event4.Attributes = append(
-		event4.Attributes,
-		abci.EventAttribute{Key: []byte(sdk.AttributeKeyAmount), Value: []byte(newCoins2.String())},
-	)
-	suite.Assert().Equal(abci.Event(event2), events[1])
-	suite.Assert().Equal(abci.Event(event3), events[3])
-	suite.Assert().Equal(abci.Event(event4), events[5])
 }
 
 func (suite *IntegrationTestSuite) TestSpendableCoins() {
@@ -1177,6 +1203,138 @@ func (suite *IntegrationTestSuite) TestSpendableCoins() {
 	ctx = ctx.WithBlockTime(now.Add(12 * time.Hour))
 	suite.Require().NoError(app.BankKeeper.DelegateCoins(ctx, addr2, addrModule, delCoins))
 	suite.Require().Equal(origCoins.Sub(delCoins...), app.BankKeeper.SpendableCoins(ctx, addr1))
+}
+
+func (suite *IntegrationTestSuite) TestSpendableCoinsWithInjection() {
+	app, ctx := suite.app, suite.ctx
+	now := time.Unix(1713586800, 0).UTC()
+	ctx = ctx.WithBlockHeader(tmproto.Header{Time: now})
+	endTime := now.Add(12 * time.Hour)
+	bk := app.BankKeeper.(*keeper.BaseKeeper)
+	origGetter := bk.GetLockedCoinsGetter()
+	defer bk.SetLockedCoinsGetter(origGetter)
+
+	baseStake := sdk.NewCoins(sdk.NewInt64Coin("stake", 100))
+	baseOther := sdk.NewCoins(sdk.NewInt64Coin("other", 50))
+	baseCoins := baseStake.Add(baseOther...)
+	vestingCoins := sdk.NewCoins(sdk.NewInt64Coin("vest", 88))
+	expVestingBalances := baseCoins.Add(vestingCoins...)
+
+	addr1 := sdk.AccAddress("addr1_______________")
+	addr2 := sdk.AccAddress("addr2_______________")
+	addrV := sdk.AccAddress("addrV_______________")
+
+	bacc := authtypes.NewBaseAccountWithAddress(addrV)
+	vacc := vesting.NewDelayedVestingAccount(bacc, vestingCoins, endTime.Unix())
+	app.AccountKeeper.SetAccount(ctx, vacc)
+
+	suite.Require().NoError(testutil.FundAccount(app.BankKeeper, ctx, addr1, baseCoins), "FundAccount(addr1)")
+	suite.Require().NoError(testutil.FundAccount(app.BankKeeper, ctx, addr2, baseCoins), "FundAccount(addr2)")
+	suite.Require().NoError(testutil.FundAccount(app.BankKeeper, ctx, addrV, expVestingBalances), "FundAccount(addrV)")
+
+	ctx = ctx.WithBlockTime(now.Add(1 * time.Hour))
+
+	bal1 := app.BankKeeper.GetAllBalances(ctx, addr1)
+	bal2 := app.BankKeeper.GetAllBalances(ctx, addr2)
+	balV := app.BankKeeper.GetAllBalances(ctx, addrV)
+	suite.Require().Equal(baseCoins.String(), bal1.String(), "GetAllBalances(addr1)")
+	suite.Require().Equal(baseCoins.String(), bal2.String(), "GetAllBalances(addr2)")
+	suite.Require().Equal(expVestingBalances.String(), balV.String(), "GetAllBalances(addrV)")
+
+	tests := []struct {
+		name     string
+		setup    func()
+		expAddr1 sdk.Coins
+		expAddr2 sdk.Coins
+		expAddrV sdk.Coins
+	}{
+		{
+			name:     "no locked coins getter",
+			expAddr1: baseCoins,
+			expAddr2: baseCoins,
+			expAddrV: expVestingBalances,
+		},
+		{
+			name:     "with only unvested coins getter",
+			setup:    func() { app.BankKeeper.AppendLockedCoinsGetter(app.BankKeeper.UnvestedCoins) },
+			expAddr1: baseCoins,
+			expAddr2: baseCoins,
+			expAddrV: baseCoins,
+		},
+		{
+			name: "with extra locked coins getters too",
+			setup: func() {
+				app.BankKeeper.AppendLockedCoinsGetter(app.BankKeeper.UnvestedCoins)
+				app.BankKeeper.AppendLockedCoinsGetter(func(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins {
+					if addr1.Equals(addr) {
+						return sdk.NewCoins(sdk.NewInt64Coin("stake", 15), sdk.NewInt64Coin("other", 32))
+					}
+					return sdk.NewCoins()
+				})
+				app.BankKeeper.AppendLockedCoinsGetter(func(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins {
+					if addr1.Equals(addr) {
+						return sdk.NewCoins(sdk.NewInt64Coin("stake", 10), sdk.NewInt64Coin("other", 18))
+					}
+					return sdk.NewCoins()
+				})
+			},
+			expAddr1: sdk.NewCoins(sdk.NewInt64Coin("stake", 75)),
+			expAddr2: baseCoins,
+			expAddrV: baseCoins,
+		},
+		{
+			name: "only appended getter that returns a negative amount",
+			setup: func() {
+				app.BankKeeper.AppendLockedCoinsGetter(func(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins {
+					return sdk.Coins{sdk.Coin{Denom: "stake", Amount: sdk.NewInt(-1)}}
+				})
+			},
+			expAddr1: baseCoins,
+			expAddr2: baseCoins,
+			expAddrV: expVestingBalances,
+		},
+		{
+			name: "only prepended getter that returns a negative amount",
+			setup: func() {
+				app.BankKeeper.PrependLockedCoinsGetter(func(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins {
+					return sdk.Coins{sdk.Coin{Denom: "stake", Amount: sdk.NewInt(-1)}}
+				})
+			},
+			expAddr1: baseCoins,
+			expAddr2: baseCoins,
+			expAddrV: expVestingBalances,
+		},
+		{
+			name: "getters return more than account has for a denom",
+			setup: func() {
+				app.BankKeeper.AppendLockedCoinsGetter(func(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins {
+					return sdk.NewCoins(sdk.NewInt64Coin("stake", 1))
+				})
+				app.BankKeeper.AppendLockedCoinsGetter(func(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins {
+					return baseStake
+				})
+			},
+			expAddr1: baseOther,
+			expAddr2: baseOther,
+			expAddrV: baseOther.Add(vestingCoins...),
+		},
+	}
+
+	for _, tc := range tests {
+		suite.Run(tc.name, func() {
+			app.BankKeeper.ClearLockedCoinsGetter()
+			if tc.setup != nil {
+				tc.setup()
+			}
+
+			spend1 := app.BankKeeper.SpendableCoins(ctx, addr1)
+			suite.Assert().Equal(tc.expAddr1.String(), spend1.String(), "SpendableCoins(addr1)")
+			spend2 := app.BankKeeper.SpendableCoins(ctx, addr2)
+			suite.Assert().Equal(tc.expAddr2.String(), spend2.String(), "SpendableCoins(addr2)")
+			spendV := app.BankKeeper.SpendableCoins(ctx, addrV)
+			suite.Assert().Equal(tc.expAddrV.String(), spendV.String(), "SpendableCoins(addrV)")
+		})
+	}
 }
 
 func (suite *IntegrationTestSuite) TestVestingAccountSend() {
@@ -1354,6 +1512,33 @@ func (suite *IntegrationTestSuite) TestDelegateCoins() {
 	vestingAcc, ok := acc.(types.VestingAccount)
 	suite.Require().True(ok)
 	suite.Require().Equal(delCoins, vestingAcc.GetDelegatedVesting())
+}
+
+func (suite *IntegrationTestSuite) TestDelegateCoinsWithRestriction() {
+	app, ctx := suite.app, suite.ctx
+
+	origCoins := sdk.NewCoins(sdk.NewInt64Coin("stake", 100))
+	delCoins := sdk.NewCoins(sdk.NewInt64Coin("stake", 50))
+
+	addr1 := sdk.AccAddress("addr1_______________")
+	addrModule := sdk.AccAddress("moduleAcc___________")
+
+	acc := app.AccountKeeper.NewAccountWithAddress(ctx, addr1)
+	macc := app.AccountKeeper.NewAccountWithAddress(ctx, addrModule) // we don't need to define an actual module account bc we just need the address for testing
+
+	app.AccountKeeper.SetAccount(ctx, acc)
+	app.AccountKeeper.SetAccount(ctx, macc)
+	suite.Require().NoError(testutil.FundAccount(app.BankKeeper, ctx, addr1, origCoins))
+
+	// Now that the accounts are set up and funded, add a send restriction that just blocks everything.
+	expErr := "this is a test restriction: restriction of no"
+	restrictionOfNo := func(_ sdk.Context, _, _ sdk.AccAddress, _ sdk.Coins) (sdk.AccAddress, error) {
+		return nil, errors.New(expErr)
+	}
+	app.BankKeeper.AppendSendRestriction(restrictionOfNo)
+
+	err := app.BankKeeper.DelegateCoins(ctx, addr1, addrModule, delCoins)
+	suite.Require().EqualError(err, expErr, "DelegateCoins")
 }
 
 func (suite *IntegrationTestSuite) TestDelegateCoins_Invalid() {

--- a/x/bank/keeper/send.go
+++ b/x/bank/keeper/send.go
@@ -197,12 +197,12 @@ func (k BaseSendKeeper) InputOutputCoins(ctx sdk.Context, input types.Input, out
 // An error is returned upon failure.
 func (k BaseSendKeeper) SendCoins(ctx sdk.Context, fromAddr sdk.AccAddress, toAddr sdk.AccAddress, amt sdk.Coins) error {
 	var err error
-	toAddr, err = k.sendRestriction.apply(ctx, fromAddr, toAddr, amt)
+	err = k.subUnlockedCoins(ctx, fromAddr, amt)
 	if err != nil {
 		return err
 	}
 
-	err = k.subUnlockedCoins(ctx, fromAddr, amt)
+	toAddr, err = k.sendRestriction.apply(ctx, fromAddr, toAddr, amt)
 	if err != nil {
 		return err
 	}

--- a/x/bank/types/restrictions.go
+++ b/x/bank/types/restrictions.go
@@ -90,6 +90,52 @@ func ComposeSendRestrictions(restrictions ...SendRestrictionFn) SendRestrictionF
 				return toAddr, err
 			}
 		}
-		return toAddr, err
+		return toAddr, nil
+	}
+}
+
+// A GetLockedCoinsFn returns some coins locked for an address.
+type GetLockedCoinsFn func(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins
+
+var _ GetLockedCoinsFn = NoOpGetLockedCoinsFn
+
+// NoOpGetLockedCoinsFn is a no-op GetLockedCoinsFn.
+func NoOpGetLockedCoinsFn(_ sdk.Context, _ sdk.AccAddress) sdk.Coins {
+	return sdk.NewCoins()
+}
+
+// Then creates a composite restriction that runs this one then the provided second one.
+func (r GetLockedCoinsFn) Then(second GetLockedCoinsFn) GetLockedCoinsFn {
+	return ComposeGetLockedCoins(r, second)
+}
+
+// ComposeGetLockedCoins combines multiple GetLockedCoinsFn into one.
+// nil entries are ignored.
+// If all entries are nil, nil is returned.
+// If exactly one entry is not nil, it is returned.
+// Otherwise, a new GetLockedCoinsFn is returned that runs the non-nil functions in the order they are given.
+// The composition runs each function returning the sum of all results.
+func ComposeGetLockedCoins(restrictions ...GetLockedCoinsFn) GetLockedCoinsFn {
+	toRun := make([]GetLockedCoinsFn, 0, len(restrictions))
+	for _, r := range restrictions {
+		if r != nil {
+			toRun = append(toRun, r)
+		}
+	}
+	switch len(toRun) {
+	case 0:
+		return nil
+	case 1:
+		return toRun[0]
+	}
+	return func(ctx sdk.Context, addr sdk.AccAddress) sdk.Coins {
+		rv := sdk.NewCoins()
+		for _, f := range toRun {
+			newLocked := f(ctx, addr)
+			if !newLocked.IsZero() {
+				rv = rv.Add(newLocked...)
+			}
+		}
+		return rv
 	}
 }

--- a/x/bank/types/restrictions_test.go
+++ b/x/bank/types/restrictions_test.go
@@ -26,7 +26,7 @@ func NewMintingRestrictionTestHelper() *MintingRestrictionTestHelper {
 	return &MintingRestrictionTestHelper{Calls: make([]*MintingRestrictionArgs, 0, 2)}
 }
 
-// RecordCall makes note that the provided args were used as a funcion call.
+// RecordCall makes note that the provided args were used as a MintingRestrictionFn call.
 func (s *MintingRestrictionTestHelper) RecordCall(name string, coins sdk.Coins) {
 	s.Calls = append(s.Calls, s.NewArgs(name, coins))
 }
@@ -410,7 +410,7 @@ func NewSendRestrictionTestHelper() *SendRestrictionTestHelper {
 	return &SendRestrictionTestHelper{Calls: make([]*SendRestrictionArgs, 0, 2)}
 }
 
-// RecordCall makes note that the provided args were used as a funcion call.
+// RecordCall makes note that the provided args were used as a SendRestrictionFn call.
 func (s *SendRestrictionTestHelper) RecordCall(name string, fromAddr, toAddr sdk.AccAddress, coins sdk.Coins) {
 	s.Calls = append(s.Calls, s.NewArgs(name, fromAddr, toAddr, coins))
 }
@@ -915,4 +915,400 @@ func TestNoOpSendRestrictionFn(t *testing.T) {
 	require.NotPanics(t, testFunc, "NoOpSendRestrictionFn")
 	assert.NoError(t, err, "NoOpSendRestrictionFn error")
 	assert.Equal(t, expAddr, addr, "NoOpSendRestrictionFn addr")
+}
+
+// GetLockedCoinsArgs are the args provided to a GetLockedCoinsFn function.
+type GetLockedCoinsArgs struct {
+	Name string
+	Addr sdk.AccAddress
+}
+
+// GetLockedCoinsTestHelper is a struct with stuff helpful for testing the GetLockedCoinsFn stuff.
+type GetLockedCoinsTestHelper struct {
+	Calls []*GetLockedCoinsArgs
+}
+
+func NewGetLockedCoinsTestHelper() *GetLockedCoinsTestHelper {
+	return &GetLockedCoinsTestHelper{Calls: make([]*GetLockedCoinsArgs, 0, 2)}
+}
+
+// RecordCall makes note that the provided args were used as a GetLockedCoinsFn call.
+func (s *GetLockedCoinsTestHelper) RecordCall(name string, addr sdk.AccAddress) {
+	s.Calls = append(s.Calls, s.NewArgs(name, addr))
+}
+
+// NewCalls is just a shorter way to create a []*GetLockedCoinsArgs.
+func (s *GetLockedCoinsTestHelper) NewCalls(args ...*GetLockedCoinsArgs) []*GetLockedCoinsArgs {
+	return args
+}
+
+// NewArgs creates a new GetLockedCoinsArgs.
+func (s *GetLockedCoinsTestHelper) NewArgs(name string, addr sdk.AccAddress) *GetLockedCoinsArgs {
+	return &GetLockedCoinsArgs{
+		Name: name,
+		Addr: addr,
+	}
+}
+
+// NamedGetter creates a new GetLockedCoinsFn function that records the arguments it's called with and returns an amount.
+func (s *GetLockedCoinsTestHelper) NamedGetter(name string, amt sdk.Coins) types.GetLockedCoinsFn {
+	return func(_ sdk.Context, addr sdk.AccAddress) sdk.Coins {
+		s.RecordCall(name, addr)
+		return amt
+	}
+}
+
+// GetLockedCoinsTestParams are parameters to test regarding calling a GetLockedCoinsFn.
+type GetLockedCoinsTestParams struct {
+	// ExpNil is whether to expect the provided GetLockedCoinsFn to be nil.
+	// If it is true, the rest of these test params are ignored.
+	ExpNil bool
+	// Addr is the address to use as input.
+	Addr sdk.AccAddress
+	// ExpCoins is the expected output coins.
+	ExpCoins sdk.Coins
+	// ExpCalls is the args of all the GetLockedCoinsFn calls that end up being made.
+	ExpCalls []*GetLockedCoinsArgs
+}
+
+// TestActual tests the provided GetLockedCoinsFn using the provided test parameters.
+func (s *GetLockedCoinsTestHelper) TestActual(t *testing.T, tp *GetLockedCoinsTestParams, actual types.GetLockedCoinsFn) {
+	t.Helper()
+	if tp.ExpNil {
+		require.Nil(t, actual, "resulting GetLockedCoinsFn")
+	} else {
+		require.NotNil(t, actual, "resulting GetLockedCoinsFn")
+		s.Calls = s.Calls[:0]
+		lockedCoins := actual(sdk.Context{}, tp.Addr)
+		assert.Equal(t, tp.ExpCoins.String(), lockedCoins.String(), "composit GetLockedCoinsFn output coins")
+		assert.Equal(t, tp.ExpCalls, s.Calls, "args given to funcs in composit GetLockedCoinsFn")
+	}
+}
+
+func TestGetLockedCoins_Then(t *testing.T) {
+	addr := sdk.AccAddress("addr________________")
+	cz := func(amount int64, denom string) sdk.Coins {
+		return sdk.NewCoins(sdk.NewInt64Coin(denom, amount))
+	}
+	cz2 := func(amount1 int64, denom1 string, amount2 int64, denom2 string) sdk.Coins {
+		return sdk.NewCoins(sdk.NewInt64Coin(denom1, amount1), sdk.NewInt64Coin(denom2, amount2))
+	}
+
+	h := NewGetLockedCoinsTestHelper()
+
+	tests := []struct {
+		name   string
+		base   types.GetLockedCoinsFn
+		second types.GetLockedCoinsFn
+		exp    *GetLockedCoinsTestParams
+	}{
+		{
+			name:   "nil nil",
+			base:   nil,
+			second: nil,
+			exp: &GetLockedCoinsTestParams{
+				ExpNil: true,
+			},
+		},
+		{
+			name:   "nil noop empty",
+			base:   nil,
+			second: h.NamedGetter("noop", sdk.Coins{}),
+			exp: &GetLockedCoinsTestParams{
+				Addr:     addr,
+				ExpCoins: sdk.Coins{},
+				ExpCalls: h.NewCalls(h.NewArgs("noop", addr)),
+			},
+		},
+		{
+			name:   "nil noop nil",
+			base:   nil,
+			second: h.NamedGetter("noop", nil),
+			exp: &GetLockedCoinsTestParams{
+				Addr:     addr,
+				ExpCoins: nil,
+				ExpCalls: h.NewCalls(h.NewArgs("noop", addr)),
+			},
+		},
+		{
+			name:   "noop nil",
+			base:   h.NamedGetter("noop", sdk.Coins{}),
+			second: nil,
+			exp: &GetLockedCoinsTestParams{
+				Addr:     addr,
+				ExpCoins: sdk.Coins{},
+				ExpCalls: h.NewCalls(h.NewArgs("noop", addr)),
+			},
+		},
+		{
+			name:   "noop noop",
+			base:   h.NamedGetter("noop1", sdk.Coins{}),
+			second: h.NamedGetter("noop2", sdk.Coins{}),
+			exp: &GetLockedCoinsTestParams{
+				Addr:     addr,
+				ExpCoins: sdk.Coins{},
+				ExpCalls: h.NewCalls(h.NewArgs("noop1", addr), h.NewArgs("noop2", addr)),
+			},
+		},
+		{
+			name:   "two with same denoms",
+			base:   h.NamedGetter("1acoin", cz(1, "acoin")),
+			second: h.NamedGetter("2acoin", cz(2, "acoin")),
+			exp: &GetLockedCoinsTestParams{
+				Addr:     addr,
+				ExpCoins: cz(3, "acoin"),
+				ExpCalls: h.NewCalls(h.NewArgs("1acoin", addr), h.NewArgs("2acoin", addr)),
+			},
+		},
+		{
+			name:   "two with different denoms",
+			base:   h.NamedGetter("acoin", cz(1, "acoin")),
+			second: h.NamedGetter("bcoin", cz(2, "bcoin")),
+			exp: &GetLockedCoinsTestParams{
+				Addr:     addr,
+				ExpCoins: cz2(1, "acoin", 2, "bcoin"),
+				ExpCalls: h.NewCalls(h.NewArgs("acoin", addr), h.NewArgs("bcoin", addr)),
+			},
+		},
+		{
+			name:   "double chain",
+			base:   types.ComposeGetLockedCoins(h.NamedGetter("r1", cz(1, "foo")), h.NamedGetter("r2", cz(2, "bar"))),
+			second: types.ComposeGetLockedCoins(h.NamedGetter("r3", cz(4, "foo")), h.NamedGetter("r4", cz(8, "bar"))),
+			exp: &GetLockedCoinsTestParams{
+				Addr:     addr,
+				ExpCoins: cz2(5, "foo", 10, "bar"),
+				ExpCalls: h.NewCalls(
+					h.NewArgs("r1", addr),
+					h.NewArgs("r2", addr),
+					h.NewArgs("r3", addr),
+					h.NewArgs("r4", addr),
+				),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var actual types.GetLockedCoinsFn
+			testFunc := func() {
+				actual = tc.base.Then(tc.second)
+			}
+			require.NotPanics(t, testFunc, "GetLockedCoinsFn.Then")
+			h.TestActual(t, tc.exp, actual)
+		})
+	}
+}
+
+func TestComposeGetLockedCoins(t *testing.T) {
+	addr := sdk.AccAddress("________addr________")
+	fnz := func(rs ...types.GetLockedCoinsFn) []types.GetLockedCoinsFn {
+		return rs
+	}
+	cz := func(amount int64, denom string) sdk.Coins {
+		return sdk.NewCoins(sdk.NewInt64Coin(denom, amount))
+	}
+	cz2 := func(amount1 int64, denom1 string, amount2 int64, denom2 string) sdk.Coins {
+		return sdk.NewCoins(sdk.NewInt64Coin(denom1, amount1), sdk.NewInt64Coin(denom2, amount2))
+	}
+
+	h := NewGetLockedCoinsTestHelper()
+
+	tests := []struct {
+		name  string
+		input []types.GetLockedCoinsFn
+		exp   *GetLockedCoinsTestParams
+	}{
+		{
+			name:  "nil list",
+			input: nil,
+			exp: &GetLockedCoinsTestParams{
+				ExpNil: true,
+			},
+		},
+		{
+			name:  "empty list",
+			input: fnz(),
+			exp: &GetLockedCoinsTestParams{
+				ExpNil: true,
+			},
+		},
+		{
+			name:  "only nil entry",
+			input: fnz(nil),
+			exp: &GetLockedCoinsTestParams{
+				ExpNil: true,
+			},
+		},
+		{
+			name:  "five nil entries",
+			input: fnz(nil, nil, nil, nil, nil),
+			exp: &GetLockedCoinsTestParams{
+				ExpNil: true,
+			},
+		},
+		{
+			name:  "only noop entry",
+			input: fnz(h.NamedGetter("noop", sdk.Coins{})),
+			exp: &GetLockedCoinsTestParams{
+				Addr:     addr,
+				ExpCoins: sdk.Coins{},
+				ExpCalls: h.NewCalls(h.NewArgs("noop", addr)),
+			},
+		},
+		{
+			name:  "only one entry",
+			input: fnz(h.NamedGetter("acorns", cz(99, "acoin"))),
+			exp: &GetLockedCoinsTestParams{
+				Addr:     addr,
+				ExpCoins: cz(99, "acoin"),
+				ExpCalls: h.NewCalls(h.NewArgs("acorns", addr)),
+			},
+		},
+		{
+			name:  "noop nil nil",
+			input: fnz(h.NamedGetter("noop", sdk.Coins{}), nil, nil),
+			exp: &GetLockedCoinsTestParams{
+				Addr:     addr,
+				ExpCoins: sdk.Coins{},
+				ExpCalls: h.NewCalls(h.NewArgs("noop", addr)),
+			},
+		},
+		{
+			name:  "nil noop nil",
+			input: fnz(nil, h.NamedGetter("noop", sdk.Coins{}), nil),
+			exp: &GetLockedCoinsTestParams{
+				Addr:     addr,
+				ExpCoins: sdk.Coins{},
+				ExpCalls: h.NewCalls(h.NewArgs("noop", addr)),
+			},
+		},
+		{
+			name:  "nil nil noop",
+			input: fnz(nil, nil, h.NamedGetter("noop", sdk.Coins{})),
+			exp: &GetLockedCoinsTestParams{
+				Addr:     addr,
+				ExpCoins: sdk.Coins{},
+				ExpCalls: h.NewCalls(h.NewArgs("noop", addr)),
+			},
+		},
+		{
+			name:  "noop noop nil",
+			input: fnz(h.NamedGetter("r1", sdk.Coins{}), h.NamedGetter("r2", sdk.Coins{}), nil),
+			exp: &GetLockedCoinsTestParams{
+				Addr:     addr,
+				ExpCoins: sdk.Coins{},
+				ExpCalls: h.NewCalls(h.NewArgs("r1", addr), h.NewArgs("r2", addr)),
+			},
+		},
+		{
+			name:  "noop nil noop",
+			input: fnz(h.NamedGetter("r1", sdk.Coins{}), nil, h.NamedGetter("r2", sdk.Coins{})),
+			exp: &GetLockedCoinsTestParams{
+				Addr:     addr,
+				ExpCoins: sdk.Coins{},
+				ExpCalls: h.NewCalls(h.NewArgs("r1", addr), h.NewArgs("r2", addr)),
+			},
+		},
+		{
+			name:  "nil noop noop",
+			input: fnz(nil, h.NamedGetter("r1", sdk.Coins{}), h.NamedGetter("r2", sdk.Coins{})),
+			exp: &GetLockedCoinsTestParams{
+				Addr:     addr,
+				ExpCoins: sdk.Coins{},
+				ExpCalls: h.NewCalls(h.NewArgs("r1", addr), h.NewArgs("r2", addr)),
+			},
+		},
+		{
+			name:  "noop noop noop",
+			input: fnz(h.NamedGetter("r1", sdk.Coins{}), h.NamedGetter("r2", sdk.Coins{}), h.NamedGetter("r3", sdk.Coins{})),
+			exp: &GetLockedCoinsTestParams{
+				Addr:     addr,
+				ExpCoins: sdk.Coins{},
+				ExpCalls: h.NewCalls(h.NewArgs("r1", addr), h.NewArgs("r2", addr), h.NewArgs("r3", addr)),
+			},
+		},
+		{
+			name:  "1acoin noop noop",
+			input: fnz(h.NamedGetter("acorns", cz(1, "acoin")), h.NamedGetter("r2", sdk.Coins{}), h.NamedGetter("r3", sdk.Coins{})),
+			exp: &GetLockedCoinsTestParams{
+				Addr:     addr,
+				ExpCoins: cz(1, "acoin"),
+				ExpCalls: h.NewCalls(h.NewArgs("acorns", addr), h.NewArgs("r2", addr), h.NewArgs("r3", addr)),
+			},
+		},
+		{
+			name:  "noop 2acoin noop",
+			input: fnz(h.NamedGetter("r1", sdk.Coins{}), h.NamedGetter("acorns", cz(2, "acoin")), h.NamedGetter("r3", sdk.Coins{})),
+			exp: &GetLockedCoinsTestParams{
+				Addr:     addr,
+				ExpCoins: cz(2, "acoin"),
+				ExpCalls: h.NewCalls(h.NewArgs("r1", addr), h.NewArgs("acorns", addr), h.NewArgs("r3", addr)),
+			},
+		},
+		{
+			name:  "noop noop 3acoin",
+			input: fnz(h.NamedGetter("r1", sdk.Coins{}), h.NamedGetter("r2", sdk.Coins{}), h.NamedGetter("acorns", cz(3, "acoin"))),
+			exp: &GetLockedCoinsTestParams{
+				Addr:     addr,
+				ExpCoins: cz(3, "acoin"),
+				ExpCalls: h.NewCalls(h.NewArgs("r1", addr), h.NewArgs("r2", addr), h.NewArgs("acorns", addr)),
+			},
+		},
+		{
+			name:  "1acoin 2bcoin 4acoin",
+			input: fnz(h.NamedGetter("acorns", cz(1, "acoin")), h.NamedGetter("bcorns", cz(2, "bcoin")), h.NamedGetter("not sea corns", cz(4, "acoin"))),
+			exp: &GetLockedCoinsTestParams{
+				Addr:     addr,
+				ExpCoins: cz2(5, "acoin", 2, "bcoin"),
+				ExpCalls: h.NewCalls(h.NewArgs("acorns", addr), h.NewArgs("bcorns", addr), h.NewArgs("not sea corns", addr)),
+			},
+		},
+		{
+			name: "big bang",
+			input: fnz(nil,
+				h.NamedGetter("noop0", nil), nil,
+				h.NamedGetter("g1", cz(1, "bananas")), nil, nil,
+				h.NamedGetter("noop1", sdk.Coins{}),
+				h.NamedGetter("noop2", sdk.Coins{}),
+				h.NamedGetter("g2", cz2(98, "bananas", 5, "apples")), nil,
+				h.NamedGetter("g3", cz(8, "apples")), nil,
+				h.NamedGetter("noop3", sdk.Coins{}),
+			),
+			exp: &GetLockedCoinsTestParams{
+				Addr:     addr,
+				ExpCoins: cz2(99, "bananas", 13, "apples"),
+				ExpCalls: h.NewCalls(
+					h.NewArgs("noop0", addr),
+					h.NewArgs("g1", addr),
+					h.NewArgs("noop1", addr),
+					h.NewArgs("noop2", addr),
+					h.NewArgs("g2", addr),
+					h.NewArgs("g3", addr),
+					h.NewArgs("noop3", addr),
+				),
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var actual types.GetLockedCoinsFn
+			testFunc := func() {
+				actual = types.ComposeGetLockedCoins(tc.input...)
+			}
+			require.NotPanics(t, testFunc, "ComposeGetLockedCoins")
+			h.TestActual(t, tc.exp, actual)
+		})
+	}
+}
+
+func TestNoOpGetLockedCoinsFn(t *testing.T) {
+	var lockedCoins sdk.Coins
+	testFunc := func() {
+		lockedCoins = types.NoOpGetLockedCoinsFn(sdk.Context{}, sdk.AccAddress{})
+	}
+	require.NotPanics(t, testFunc, "NoOpGetLockedCoinsFn")
+	if assert.NotNil(t, lockedCoins, "NoOpGetLockedCoinsFn coins") {
+		assert.Equal(t, "", lockedCoins.String(), "NoOpGetLockedCoinsFn coins")
+	}
 }

--- a/x/sanction/keeper/send_restriction_test.go
+++ b/x/sanction/keeper/send_restriction_test.go
@@ -107,9 +107,13 @@ func (s *SendRestrictionTestSuite) TestBankSendCoinsUsesSendRestrictionFn() {
 	s.ReqOKAddPermSanct("sanctionedAddr", sanctionedAddr)
 
 	s.Run("SendCoins from sanctioned addr returns error", func() {
+		ctx, writeCache := s.SdkCtx.CacheContext()
 		expErr := "cannot send from " + sanctionedAddr.String() + ": account is sanctioned"
-		err := s.App.BankKeeper.SendCoins(s.SdkCtx, sanctionedAddr, otherAddr, cz(5_000_000_000))
+		err := s.App.BankKeeper.SendCoins(ctx, sanctionedAddr, otherAddr, cz(5_000_000_000))
 		s.Assert().EqualError(err, expErr, "SendCoins from sanctioned address error")
+		if err == nil {
+			writeCache()
+		}
 	})
 
 	s.Run("SendCoins to sanctioned addr does not return an error", func() {


### PR DESCRIPTION
## Description

This PR backports the following PRs to the `release-pio/v0.46.x` branch:
* #577 
* #578 

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

* [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] added `!` to the type prefix if API or client breaking change
* [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
* [ ] provided a link to the relevant issue or specification
* [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/docs/building-modules)
* [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
* [ ] added a changelog entry to `CHANGELOG.md`
* [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
* [ ] updated the relevant documentation or specification
* [ ] reviewed "Files changed" and left comments if necessary
* [ ] run `make lint` and `make test`
* [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

* [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
* [ ] confirmed `!` in the type prefix if API or client breaking change
* [ ] confirmed all author checklist items have been addressed 
* [ ] reviewed state machine logic
* [ ] reviewed API design and naming
* [ ] reviewed documentation is accurate
* [ ] reviewed tests and test coverage
* [ ] manually tested (if applicable)
