### PR TITLE
Allow MsgMultiSend to have multiple inputs when there's only one output.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,14 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * [#578](https://github.com/provenance-io/cosmos-sdk/pull/578) Add `binary_version` to the `NodeInfo` object returned by status command.
 * [#577](https://github.com/provenance-io/cosmos-sdk/pull/577) Add an injectable `GetLockedCoinsFn` to the bank module.
 
+### Improvements
+
+* [#581](https://github.com/provenance-io/cosmos-sdk/pull/581) For `MsgMultiSend` and `InputOutputCoins`, allow many inputs when there's a single output.
+
+### API Breaking
+
+* [#581](https://github.com/provenance-io/cosmos-sdk/pull/581) The `InputOutputCoins` once again takes in multiple inputs. It returns an error if there are multiple inputs and multiple outputs.
+
 ---
 
 ## [v0.46.13-pio-1](https://github.com/provenance-io/cosmos-sdk/releases/tag/v0.46.13-pio-1) - 2023-06-09

--- a/x/bank/app_test.go
+++ b/x/bank/app_test.go
@@ -272,7 +272,7 @@ func TestMsgMultiSendMultipleInOut(t *testing.T) {
 			{addr3, sdk.Coins{}},
 		},
 	}
-	expErr := "multiple senders not allowed"
+	expErr := types.ErrManyToMany.Error()
 
 	header := tmproto.Header{Height: app.LastBlockHeight() + 1}
 	txGen := simapp.MakeTestEncodingConfig().TxConfig

--- a/x/bank/keeper/msg_server.go
+++ b/x/bank/keeper/msg_server.go
@@ -101,7 +101,7 @@ func (k msgServer) MultiSend(goCtx context.Context, msg *types.MsgMultiSend) (*t
 		}
 	}
 
-	err := k.InputOutputCoins(ctx, msg.Inputs[0], msg.Outputs)
+	err := k.InputOutputCoins(ctx, msg.Inputs, msg.Outputs)
 	if err != nil {
 		return nil, err
 	}

--- a/x/bank/spec/02_keepers.md
+++ b/x/bank/spec/02_keepers.md
@@ -110,7 +110,7 @@ type SendKeeper interface {
     PrependSendRestriction(restriction types.SendRestrictionFn)
     ClearSendRestriction()
 
-    InputOutputCoins(ctx sdk.Context, input types.Input, outputs []types.Output) error
+    InputOutputCoins(ctx sdk.Context, inputs []types.Input, outputs []types.Output) error
     SendCoins(ctx sdk.Context, fromAddr, toAddr sdk.AccAddress, amt sdk.Coins) error
 
     GetParams(ctx sdk.Context) types.Params

--- a/x/bank/types/errors.go
+++ b/x/bank/types/errors.go
@@ -13,5 +13,5 @@ var (
 	ErrDenomMetadataNotFound = sdkerrors.Register(ModuleName, 6, "client denom metadata not found")
 	ErrInvalidKey            = sdkerrors.Register(ModuleName, 7, "invalid key")
 	ErrDuplicateEntry        = sdkerrors.Register(ModuleName, 8, "duplicate entry")
-	ErrMultipleSenders       = sdkerrors.Register(ModuleName, 9, "multiple senders not allowed")
+	ErrManyToMany            = sdkerrors.Register(ModuleName, 9, "multiple senders to multiple receivers not allowed")
 )

--- a/x/quarantine/keeper/send_restriction_test.go
+++ b/x/quarantine/keeper/send_restriction_test.go
@@ -229,14 +229,14 @@ func (s *TestSuite) TestBankInputOutputCoinsUsesSendRestrictionFn() {
 	s.Require().NoError(testutil.FundAccount(s.app.BankKeeper, s.sdkCtx, s.addr5, cz(888)), "FundAccount addr5 888%s", denom)
 
 	// Do an InputOutputCoins from 5 to 1, 2, 3, and 4.
-	input := banktypes.Input{Address: s.addr5.String(), Coins: cz(322)}
+	inputs := []banktypes.Input{{Address: s.addr5.String(), Coins: cz(322)}}
 	outputs := []banktypes.Output{
 		{Address: s.addr1.String(), Coins: cz(33)},
 		{Address: s.addr2.String(), Coins: cz(55)},
 		{Address: s.addr3.String(), Coins: cz(89)},
 		{Address: s.addr4.String(), Coins: cz(145)},
 	}
-	s.Require().NoError(s.app.BankKeeper.InputOutputCoins(s.sdkCtx, input, outputs), "InputOutputCoins")
+	s.Require().NoError(s.app.BankKeeper.InputOutputCoins(s.sdkCtx, inputs, outputs), "InputOutputCoins")
 
 	expBalances := []struct {
 		name string

--- a/x/sanction/keeper/send_restriction_test.go
+++ b/x/sanction/keeper/send_restriction_test.go
@@ -156,13 +156,13 @@ func (s *SendRestrictionTestSuite) TestBankInputOutputCoinsUsesSendRestrictionFn
 	s.ReqOKAddPermSanct("sanctionedAddr", sanctionedAddr)
 
 	// Do an InputOutputCoins from the sanctioned address to the others.
-	input := banktypes.Input{Address: sanctionedAddr.String(), Coins: cz(6_000)}
+	inputs := []banktypes.Input{{Address: sanctionedAddr.String(), Coins: cz(6_000)}}
 	outputs := []banktypes.Output{
 		{Address: otherAddr1.String(), Coins: cz(1_000)},
 		{Address: otherAddr2.String(), Coins: cz(2_000)},
 		{Address: otherAddr3.String(), Coins: cz(3_000)},
 	}
-	err := s.App.BankKeeper.InputOutputCoins(s.SdkCtx, input, outputs)
+	err := s.App.BankKeeper.InputOutputCoins(s.SdkCtx, inputs, outputs)
 
 	s.Run("error is as expected", func() {
 		exp := "cannot send from " + sanctionedAddr.String() + ": account is sanctioned"


### PR DESCRIPTION
## Description

Make `MsgMultiSend` allow multiple inputs when there's only one output.
This also meant changing `InputOutputCoins` back to taking in multiple inputs.

So now, `InputOutputCoins` can either be one-to-one, one-to-many, or many-to-one (but not many-to-many). This will help facility exchange functions.

It'd be nice to allow many-to-many, again, but that's a non-trivial change due to the send restrictions. So for now, that functionality is omitted.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
