### PR TITLE
Add BlockedAddr check in CreatePeriodicVestingAccount (GHSA-4j93-fm92-rp4m).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,12 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
+* nothing
+
+---
+
+## [v0.46.13-pio-2](https://github.com/provenance-io/cosmos-sdk/releases/tag/v0.46.13-pio-2) - 2023-08-11
+
 ### Features
 
 * [#578](https://github.com/provenance-io/cosmos-sdk/pull/578) Add `binary_version` to the `NodeInfo` object returned by status command.
@@ -46,18 +52,23 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Improvements
 
+* [#580](https://github.com/provenance-io/cosmos-sdk/pull/580) Add SpendableBalances query CLI command.
 * [#581](https://github.com/provenance-io/cosmos-sdk/pull/581) For `MsgMultiSend` and `InputOutputCoins`, allow many inputs when there's a single output.
 
 ### Bug Fixes
 
 * [#582](https://github.com/provenance-io/cosmos-sdk/pull/582) Prevent locked coins from being delegated. Coins locked in a vesting account can still be delegated though.
 * [#582](https://github.com/provenance-io/cosmos-sdk/pull/582) Staking simulations can no longer try to delegate coins locked outside of vesting.
-* (x/auth/vesting) [GHSA-4j93-fm92-rp4m](https://github.com/cosmos/cosmos-sdk/security/advisories/GHSA-4j93-fm92-rp4m) Add `BlockedAddr` check in `CreatePeriodicVestingAccount`.
 
 ### API Breaking
 
 * [#581](https://github.com/provenance-io/cosmos-sdk/pull/581) The `InputOutputCoins` once again takes in multiple inputs. It returns an error if there are multiple inputs and multiple outputs.
 * [#582](https://github.com/provenance-io/cosmos-sdk/pull/582) The `SimulateFromSeed` function now also returns the last block time simulated.
+
+### Full Commit History
+
+* https://github.com/provenance-io/cosmos-sdk/compare/v0.46.13-pio-1...v0.46.13-pio-2
+* https://github.com/provenance-io/cosmos-sdk/compare/v0.46.13..v0.46.13-pio-2
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,9 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
-* nothing
+### Bug Fixes
+
+* (x/auth/vesting) [GHSA-4j93-fm92-rp4m](https://github.com/cosmos/cosmos-sdk/security/advisories/GHSA-4j93-fm92-rp4m) Add `BlockedAddr` check in `CreatePeriodicVestingAccount`.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 * [#582](https://github.com/provenance-io/cosmos-sdk/pull/582) Prevent locked coins from being delegated. Coins locked in a vesting account can still be delegated though.
 * [#582](https://github.com/provenance-io/cosmos-sdk/pull/582) Staking simulations can no longer try to delegate coins locked outside of vesting.
+* (x/auth/vesting) [GHSA-4j93-fm92-rp4m](https://github.com/cosmos/cosmos-sdk/security/advisories/GHSA-4j93-fm92-rp4m) Add `BlockedAddr` check in `CreatePeriodicVestingAccount`.
 
 ### API Breaking
 

--- a/x/auth/vesting/msg_server.go
+++ b/x/auth/vesting/msg_server.go
@@ -168,6 +168,10 @@ func (s msgServer) CreatePeriodicVestingAccount(goCtx context.Context, msg *type
 		return nil, err
 	}
 
+	if s.BankKeeper.BlockedAddr(to) {
+		return nil, sdkerrors.Wrapf(sdkerrors.ErrUnauthorized, "%s is not allowed to receive funds", msg.ToAddress)
+	}
+
 	if acc := ak.GetAccount(ctx, to); acc != nil {
 		return nil, sdkerrors.Wrapf(sdkerrors.ErrInvalidRequest, "account %s already exists", msg.ToAddress)
 	}


### PR DESCRIPTION
## Description

Add `BlockedAddr` check in `CreatePeriodicVestingAccount` to address [GHSA-4j93-fm92-rp4m](https://github.com/cosmos/cosmos-sdk/security/advisories/GHSA-4j93-fm92-rp4m).

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [x] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
