### PR TITLE
Prov: Add the --expedite flag to AddGovPropFlagsToCmd and ReadGovPropCmdFlags. Mark v0.53.5-pio-2.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,9 +38,20 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased Provenance
 
+* nothing
+
+---
+
+## [v0.53.5-pio-2](https://github.com/provenance-io/cosmos-sdk/releases/tag/v0.53.5-pio-2) - 2026-01-28
+
 ### Features
 
 * [#633](https://github.com/provenance-io/cosmos-sdk/pull/633) Provenance: Add the --expedite flag to gov prop commands.
+
+### Full Commit History
+
+* https://github.com/provenance-io/cosmos-sdk/compare/v0.53.5-pio-1..v0.53.5-pio-2
+* https://github.com/provenance-io/cosmos-sdk/compare/v0.53.5..v0.53.5-pio-2
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,9 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased Provenance
 
-* nothing
+### Features
+
+* [#633](https://github.com/provenance-io/cosmos-sdk/pull/633) Provenance: Add the --expedite flag to gov prop commands.
 
 ---
 

--- a/x/gov/client/cli/tx.go
+++ b/x/gov/client/cli/tx.go
@@ -27,7 +27,7 @@ const (
 	flagStatus    = "status"
 	FlagMetadata  = "metadata"
 	FlagSummary   = "summary"
-	FlagExpedited = "expedited"
+	FlagExpedite  = "expedite"
 
 	// Deprecated: only used for v1beta1 legacy proposals.
 	FlagProposal = "proposal"

--- a/x/gov/client/cli/util.go
+++ b/x/gov/client/cli/util.go
@@ -131,7 +131,7 @@ func AddGovPropFlagsToCmd(cmd *cobra.Command) {
 	cmd.Flags().String(FlagMetadata, "", "The metadata to include with the governance proposal")
 	cmd.Flags().String(FlagTitle, "", "The title to put on the governance proposal")
 	cmd.Flags().String(FlagSummary, "", "The summary to include with the governance proposal")
-	// cmd.Flags().Bool(FlagExpedited, false, "Whether to expedite the governance proposal") // cannot be enabled because of IBC redefining this flag in `upgrade-channels` command.
+	cmd.Flags().Bool(FlagExpedite, false, "Expedite the governance proposal")
 }
 
 // ReadGovPropCmdFlags parses a MsgSubmitProposal from the provided context and flags.
@@ -167,10 +167,10 @@ func ReadGovPropCmdFlags(proposer string, flagSet *pflag.FlagSet) (*govv1.MsgSub
 		return nil, fmt.Errorf("could not read summary: %w", err)
 	}
 
-	// rv.Expedited, err = flagSet.GetBool(FlagExpedited)
-	// if err != nil {
-	// 	return nil, fmt.Errorf("could not read expedited: %w", err)
-	// }
+	rv.Expedited, err = flagSet.GetBool(FlagExpedite)
+	if err != nil {
+		return nil, fmt.Errorf("could not read expedite flag: %w", err)
+	}
 
 	rv.Proposer = proposer
 
@@ -182,7 +182,7 @@ func ReadGovPropCmdFlags(proposer string, flagSet *pflag.FlagSet) (*govv1.MsgSub
 //
 // See also AddGovPropFlagsToCmd.
 //
-// Deprecated: use ReadPropCmdFlags instead, as this depends on global bech32 prefixes.
+// Deprecated: use ReadGovPropCmdFlags instead, as this depends on global bech32 prefixes.
 func ReadGovPropFlags(clientCtx client.Context, flagSet *pflag.FlagSet) (*govv1.MsgSubmitProposal, error) {
 	return ReadGovPropCmdFlags(clientCtx.GetFromAddress().String(), flagSet)
 }


### PR DESCRIPTION
## Description

This PR adds the `--expedite` flag (and handling) to the `AddGovPropFlagsToCmd` and `ReadGovPropCmdFlags` helpers.

It can't be called `--expedited` because apparently that clashes with the IBC `upgrade-channels` command.

---

### Author Checklist

*All items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.*

I have...

- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] added `!` to the type prefix if API or client breaking change
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link to the relevant issue or specification
- [ ] followed the guidelines for [building modules](https://github.com/cosmos/cosmos-sdk/blob/main/docs/building-modules)
- [ ] included the necessary unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/main/CONTRIBUTING.md#testing)
- [ ] added a changelog entry to `CHANGELOG.md`
- [ ] included comments for [documenting Go code](https://blog.golang.org/godoc)
- [ ] updated the relevant documentation or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all CI checks have passed

### Reviewers Checklist

*All items are required. Please add a note if the item is not applicable and please add
your handle next to the items reviewed if you only reviewed selected items.*

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed `!` in the type prefix if API or client breaking change
- [ ] confirmed all author checklist items have been addressed 
- [ ] reviewed state machine logic
- [ ] reviewed API design and naming
- [ ] reviewed documentation is accurate
- [ ] reviewed tests and test coverage
- [ ] manually tested (if applicable)
